### PR TITLE
feat: Unify booking nomenclature and support multi-industry services

### DIFF
--- a/actions/professional-actions.ts
+++ b/actions/professional-actions.ts
@@ -1,170 +1,201 @@
-"use server"
+'use server';
 
-import { supabaseServer } from "@/lib/supabase-server"
-import type { Database } from "@/lib/database.types"
-import { revalidatePath } from "next/cache"
+import { supabaseServer } from '@/lib/supabase-server';
+import type { Database } from '@/lib/database.types';
+import { revalidatePath } from 'next/cache';
 
-type Professional = Database["public"]["Tables"]["professionals"]["Row"]
-type ProfessionalInsert = Database["public"]["Tables"]["professionals"]["Insert"]
-type ProfessionalUpdate = Database["public"]["Tables"]["professionals"]["Update"]
+type Professional = Database['public']['Tables']['professionals']['Row'];
+type ProfessionalInsert =
+  Database['public']['Tables']['professionals']['Insert'];
+type ProfessionalUpdate =
+  Database['public']['Tables']['professionals']['Update'];
 
 export async function createProfessional(professionalData: ProfessionalInsert) {
   try {
-    const { data, error } = await supabaseServer.from("professionals").insert(professionalData).select().single()
+    const { data, error } = await supabaseServer
+      .from('professionals')
+      .insert(professionalData)
+      .select()
+      .single();
 
     if (error) {
-      console.error("Error creating professional:", error)
-      return { success: false, error: error.message }
+      console.error('Error creating professional:', error);
+      return { success: false, error: error.message };
     }
 
-    revalidatePath("/professional")
-    revalidatePath("/company")
-    return { success: true, data }
+    revalidatePath('/professional');
+    revalidatePath('/company');
+    return { success: true, data };
   } catch (error) {
-    console.error("Error creating professional:", error)
-    return { success: false, error: "Error interno del servidor" }
+    console.error('Error creating professional:', error);
+    return { success: false, error: 'Error interno del servidor' };
   }
 }
 
 export async function getProfessional(
-  professionalId: string,
+  professionalId: string
 ): Promise<{ success: boolean; data?: Professional; error?: string }> {
   try {
-    const { data, error } = await supabaseServer.from("professionals").select("*").eq("id", professionalId).single()
+    const { data, error } = await supabaseServer
+      .from('professionals')
+      .select('*')
+      .eq('id', professionalId)
+      .single();
 
     if (error) {
-      console.error("Error getting professional:", error)
-      return { success: false, error: error.message }
+      console.error('Error getting professional:', error);
+      return { success: false, error: error.message };
     }
 
-    return { success: true, data }
+    return { success: true, data };
   } catch (error) {
-    console.error("Error getting professional:", error)
-    return { success: false, error: "Error interno del servidor" }
+    console.error('Error getting professional:', error);
+    return { success: false, error: 'Error interno del servidor' };
   }
 }
 
 export async function getProfessionalByUserId(
-  userId: string,
+  userId: string
 ): Promise<{ success: boolean; data?: Professional; error?: string }> {
   try {
-    const { data, error } = await supabaseServer.from("professionals").select("*").eq("user_id", userId).single()
+    const { data, error } = await supabaseServer
+      .from('professionals')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
 
     if (error) {
-      console.error("Error getting professional by user:", error)
-      return { success: false, error: error.message }
+      console.error('Error getting professional by user:', error);
+      return { success: false, error: error.message };
     }
 
-    return { success: true, data }
+    return { success: true, data };
   } catch (error) {
-    console.error("Error getting professional by user:", error)
-    return { success: false, error: "Error interno del servidor" }
+    console.error('Error getting professional by user:', error);
+    return { success: false, error: 'Error interno del servidor' };
   }
 }
 
 export async function getProfessionalsByCompany(
-  companyId: string,
+  companyId: string
 ): Promise<{ success: boolean; data?: Professional[]; error?: string }> {
   try {
     const { data, error } = await supabaseServer
-      .from("professionals")
-      .select("*")
-      .eq("company_id", companyId)
-      .eq("is_active", true)
-      .order("name")
+      .from('professionals')
+      .select('*')
+      .eq('company_id', companyId)
+      .eq('is_active', true)
+      .order('name');
 
     if (error) {
-      console.error("Error getting professionals by company:", error)
-      return { success: false, error: error.message }
+      console.error('Error getting professionals by company:', error);
+      return { success: false, error: error.message };
     }
 
-    return { success: true, data }
+    return { success: true, data };
   } catch (error) {
-    console.error("Error getting professionals by company:", error)
-    return { success: false, error: "Error interno del servidor" }
+    console.error('Error getting professionals by company:', error);
+    return { success: false, error: 'Error interno del servidor' };
   }
 }
 
-export async function getAllProfessionals(): Promise<{ success: boolean; data?: Professional[]; error?: string }> {
-  try {
-    const { data, error } = await supabaseServer.from("professionals").select("*").eq("is_active", true).order("name")
-
-    if (error) {
-      console.error("Error getting professionals:", error)
-      return { success: false, error: error.message }
-    }
-
-    return { success: true, data }
-  } catch (error) {
-    console.error("Error getting professionals:", error)
-    return { success: false, error: "Error interno del servidor" }
-  }
-}
-
-export async function updateProfessional(professionalId: string, updates: ProfessionalUpdate) {
+export async function getAllProfessionals(): Promise<{
+  success: boolean;
+  data?: Professional[];
+  error?: string;
+}> {
   try {
     const { data, error } = await supabaseServer
-      .from("professionals")
-      .update({ ...updates, updated_at: new Date().toISOString() })
-      .eq("id", professionalId)
-      .select()
-      .single()
+      .from('professionals')
+      .select('*')
+      .eq('is_active', true)
+      .order('name');
 
     if (error) {
-      console.error("Error updating professional:", error)
-      return { success: false, error: error.message }
+      console.error('Error getting professionals:', error);
+      return { success: false, error: error.message };
     }
 
-    revalidatePath("/professional")
-    revalidatePath("/company")
-    return { success: true, data }
+    return { success: true, data };
   } catch (error) {
-    console.error("Error updating professional:", error)
-    return { success: false, error: "Error interno del servidor" }
+    console.error('Error getting professionals:', error);
+    return { success: false, error: 'Error interno del servidor' };
+  }
+}
+
+export async function updateProfessional(
+  professionalId: string,
+  updates: ProfessionalUpdate
+) {
+  try {
+    const { data, error } = await supabaseServer
+      .from('professionals')
+      .update({ ...updates, updated_at: new Date().toISOString() })
+      .eq('id', professionalId)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error updating professional:', error);
+      return { success: false, error: error.message };
+    }
+
+    revalidatePath('/professional');
+    revalidatePath('/company');
+    return { success: true, data };
+  } catch (error) {
+    console.error('Error updating professional:', error);
+    return { success: false, error: 'Error interno del servidor' };
   }
 }
 
 export async function deleteProfessional(professionalId: string) {
   try {
-    const { error } = await supabaseServer.from("professionals").delete().eq("id", professionalId)
+    const { error } = await supabaseServer
+      .from('professionals')
+      .delete()
+      .eq('id', professionalId);
 
     if (error) {
-      console.error("Error deleting professional:", error)
-      return { success: false, error: error.message }
+      console.error('Error deleting professional:', error);
+      return { success: false, error: error.message };
     }
 
-    revalidatePath("/professional")
-    revalidatePath("/company")
-    return { success: true }
+    revalidatePath('/professional');
+    revalidatePath('/company');
+    return { success: true };
   } catch (error) {
-    console.error("Error deleting professional:", error)
-    return { success: false, error: "Error interno del servidor" }
+    console.error('Error deleting professional:', error);
+    return { success: false, error: 'Error interno del servidor' };
   }
 }
 
-export async function toggleProfessionalStatus(professionalId: string, isActive: boolean) {
+export async function toggleProfessionalStatus(
+  professionalId: string,
+  isActive: boolean
+) {
   try {
     const { data, error } = await supabaseServer
-      .from("professionals")
+      .from('professionals')
       .update({
         is_active: isActive,
         updated_at: new Date().toISOString(),
       })
-      .eq("id", professionalId)
+      .eq('id', professionalId)
       .select()
-      .single()
+      .single();
 
     if (error) {
-      console.error("Error toggling professional status:", error)
-      return { success: false, error: error.message }
+      console.error('Error toggling professional status:', error);
+      return { success: false, error: error.message };
     }
 
-    revalidatePath("/professional")
-    revalidatePath("/company")
-    return { success: true, data }
+    revalidatePath('/professional');
+    revalidatePath('/company');
+    return { success: true, data };
   } catch (error) {
-    console.error("Error toggling professional status:", error)
-    return { success: false, error: "Error interno del servidor" }
+    console.error('Error toggling professional status:', error);
+    return { success: false, error: 'Error interno del servidor' };
   }
 }
 
@@ -172,37 +203,42 @@ export async function getProfessionalStats(professionalId: string) {
   try {
     // Get professional bookings for stats
     const { data: bookings, error: bookingsError } = await supabaseServer
-      .from("bookings")
-      .select("*")
-      .eq("professional_id", professionalId)
+      .from('bookings')
+      .select('*')
+      .eq('professional_id', professionalId);
 
     if (bookingsError) {
-      console.error("Error getting professional bookings:", bookingsError)
-      return { success: false, error: bookingsError.message }
+      console.error('Error getting professional bookings:', bookingsError);
+      return { success: false, error: bookingsError.message };
     }
 
-    const today = new Date().toISOString().split("T")[0]
-    const thisWeek = new Date()
-    thisWeek.setDate(thisWeek.getDate() - 7)
-    const weekStart = thisWeek.toISOString().split("T")[0]
+    const today = new Date().toISOString().split('T')[0];
+    const thisWeek = new Date();
+    thisWeek.setDate(thisWeek.getDate() - 7);
+    const weekStart = thisWeek.toISOString().split('T')[0];
 
-    const todayBookings = bookings?.filter((b) => b.date === today) || []
-    const pendingBookings = bookings?.filter((b) => b.status === "pending") || []
-    const weeklyBookings = bookings?.filter((b) => b.date >= weekStart) || []
-    const completedBookings = bookings?.filter((b) => b.status === "completed") || []
+    const todayBookings = bookings?.filter((b) => b.date === today) || [];
+    const pendingBookings =
+      bookings?.filter((b) => b.status === 'pending') || [];
+    const weeklyBookings = bookings?.filter((b) => b.date >= weekStart) || [];
+    const completedBookings =
+      bookings?.filter((b) => b.status === 'completed') || [];
 
-    const monthlyRevenue = completedBookings.reduce((sum, booking) => sum + booking.price, 0)
+    const monthlyRevenue = completedBookings.reduce(
+      (sum, booking) => sum + booking.price,
+      0
+    );
 
     const stats = {
-      todayAppointments: todayBookings.length,
+      todayBookings: todayBookings.length,
       pendingBookings: pendingBookings.length,
-      weeklyAppointments: weeklyBookings.length,
+      weeklyBookings: weeklyBookings.length,
       monthlyRevenue,
-    }
+    };
 
-    return { success: true, data: stats }
+    return { success: true, data: stats };
   } catch (error) {
-    console.error("Error getting professional stats:", error)
-    return { success: false, error: "Error interno del servidor" }
+    console.error('Error getting professional stats:', error);
+    return { success: false, error: 'Error interno del servidor' };
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,140 +1,152 @@
-"use client"
+'use client';
 
-import { useEffect, useState } from "react"
-import { useRouter } from "next/navigation"
-import { useAuth } from "@/hooks/use-auth"
-import { AuthGuard } from "@/components/auth/auth-guard"
-import { LoginForm } from "@/components/auth/login-form"
-import { RegisterForm } from "@/components/auth/register-form"
-import { ClientDashboard } from "@/components/client/client-dashboard"
-import { ProfessionalDashboard } from "@/components/professional/professional-dashboard"
-import { CompanyDashboard } from "@/components/company/company-dashboard"
-import { ClinicSelection } from "@/components/professional/clinic-selection"
-import { Button } from "@/components/ui/button"
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/hooks/use-auth';
+import { LoginForm } from '@/components/auth/login-form';
+import { RegisterForm } from '@/components/auth/register-form';
+import { ClientDashboard } from '@/components/client/client-dashboard';
+import { ProfessionalDashboard } from '@/components/professional/professional-dashboard';
+import { CompanyDashboard } from '@/components/company/company-dashboard';
+import { ClinicSelection } from '@/components/professional/clinic-selection';
+import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
 
 function AuthenticatedApp() {
-  const { profile, signOut } = useAuth()
+  const { profile, session, isLoading } = useAuth();
   const [currentView, setCurrentView] = useState<
-    "client-dashboard" | "professional-dashboard" | "company-dashboard" | "clinic-selection"
+    | 'client-dashboard'
+    | 'professional-dashboard'
+    | 'company-dashboard'
+    | 'clinic-selection'
   >(() => {
-    if (!profile) return "client-dashboard"
+    if (!profile) return 'client-dashboard';
 
     switch (profile.user_type) {
-      case "Cliente":
-        return "client-dashboard"
-      case "Profesional":
-        return "clinic-selection"
-      case "Empresa":
-        return "company-dashboard"
+      case 'Cliente':
+        return 'client-dashboard';
+      case 'Profesional':
+        return 'clinic-selection';
+      case 'Empresa':
+        return 'company-dashboard';
       default:
-        return "client-dashboard"
+        return 'client-dashboard';
     }
-  })
+  });
 
+  // Mostrar loading mientras se carga el perfil
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4 text-blue-600" />
+          <p className="text-gray-600">Cargando...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Si no hay sesión, mostrar formularios de auth
+  if (!session) {
+    return <AuthForms />;
+  }
+
+  // Si no hay perfil, mostrar error
   if (!profile) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <div className="text-center">
           <p className="text-gray-600">Error: No se pudo cargar el perfil</p>
-          <Button onClick={signOut} className="mt-4">
-            Cerrar sesión
-          </Button>
         </div>
       </div>
-    )
+    );
   }
 
   const handleClinicSelection = () => {
-    setCurrentView("professional-dashboard")
-  }
+    setCurrentView('professional-dashboard');
+  };
 
-  // Convertir profile a formato esperado por los dashboards
-  const userData = {
-    id: profile.id,
-    name: profile.full_name || "Usuario",
-    email: profile.email,
-    phone: profile.phone || "",
-    userType: profile.user_type,
-    avatar: profile.avatar_url || "/placeholder.svg?height=40&width=40",
-    memberSince: profile.created_at
-      ? new Date(profile.created_at).toLocaleDateString("es-ES", {
-          year: "numeric",
-          month: "long",
-        })
-      : "Reciente",
-    totalBookings: 0,
-  }
-
-  const handleLogout = async () => {
-    await signOut()
-  }
+  // Actualizar la vista cuando cambie el perfil
+  useEffect(() => {
+    if (profile) {
+      switch (profile.user_type) {
+        case 'Cliente':
+          setCurrentView('client-dashboard');
+          break;
+        case 'Profesional':
+          setCurrentView('clinic-selection');
+          break;
+        case 'Empresa':
+          setCurrentView('company-dashboard');
+          break;
+        default:
+          setCurrentView('client-dashboard');
+      }
+    }
+  }, [profile]);
 
   switch (currentView) {
-    case "client-dashboard":
-      return <ClientDashboard user={userData} onLogout={handleLogout} />
-    case "clinic-selection":
-      return <ClinicSelection onContinue={handleClinicSelection} />
-    case "professional-dashboard":
-      return <ProfessionalDashboard user={userData} onLogout={handleLogout} />
-    case "company-dashboard":
-      return <CompanyDashboard user={userData} onLogout={handleLogout} />
+    case 'client-dashboard':
+      return <ClientDashboard />;
+    case 'clinic-selection':
+      return <ClinicSelection onContinue={handleClinicSelection} />;
+    case 'professional-dashboard':
+      return <ProfessionalDashboard />;
+    case 'company-dashboard':
+      return <CompanyDashboard />;
     default:
-      return <ClientDashboard user={userData} onLogout={handleLogout} />
+      return <ClientDashboard />;
   }
 }
 
-function AuthWrapper() {
-  const [showRegister, setShowRegister] = useState(false)
+function AuthForms() {
+  const [showRegister, setShowRegister] = useState(false);
 
   return (
-    <AuthGuard
-      fallback={
+    <div className="min-h-screen bg-gray-50">
+      {showRegister ? (
         <div>
-          {showRegister ? (
-            <div>
-              <RegisterForm onSuccess={() => setShowRegister(false)} />
-              <div className="fixed bottom-4 right-4">
-                <Button variant="outline" onClick={() => setShowRegister(false)}>
-                  ¿Ya tienes cuenta? Inicia sesión
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <div>
-              <LoginForm onSuccess={() => {}} />
-              <div className="fixed bottom-4 right-4">
-                <Button variant="outline" onClick={() => setShowRegister(true)}>
-                  ¿No tienes cuenta? Regístrate
-                </Button>
-              </div>
-            </div>
-          )}
+          <RegisterForm />
+          <div className="fixed bottom-4 right-4">
+            <Button variant="outline" onClick={() => setShowRegister(false)}>
+              ¿Ya tienes cuenta? Inicia sesión
+            </Button>
+          </div>
         </div>
-      }
-    >
-      <AuthenticatedApp />
-    </AuthGuard>
-  )
+      ) : (
+        <div>
+          <LoginForm />
+          <div className="fixed bottom-4 right-4">
+            <Button variant="outline" onClick={() => setShowRegister(true)}>
+              ¿No tienes cuenta? Regístrate
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default function Home() {
-  const { session, signIn } = useAuth()
-  const router = useRouter()
+  const { session } = useAuth();
+  const router = useRouter();
 
   useEffect(() => {
     if (session) {
-      router.replace("/dashboard")
+      router.replace('/dashboard');
     }
-  }, [session, router])
+  }, [session, router]);
 
-  const handleLogin = () => {
-    router.push("/auth/login")
+  // Si hay sesión, mostrar la app autenticada
+  if (session) {
+    return <AuthenticatedApp />;
   }
 
+  // Si no hay sesión, mostrar página de bienvenida
   return (
     <main className="flex h-screen flex-col items-center justify-center gap-6">
       <h1 className="text-3xl font-bold">Bienvenido al sistema de reservas</h1>
-      <Button onClick={handleLogin}>Iniciar sesión demo</Button>
+      <AuthForms />
     </main>
-  )
+  );
 }

--- a/components/client/booking-history.tsx
+++ b/components/client/booking-history.tsx
@@ -1,120 +1,148 @@
-"use client"
+'use client';
 
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Separator } from "@/components/ui/separator"
-import { User, Calendar, Clock, MapPin, FileText, Star, Download, Filter } from "lucide-react"
-import { useState } from "react"
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import {
+  User,
+  Calendar,
+  Clock,
+  MapPin,
+  FileText,
+  Star,
+  Download,
+  Filter,
+} from 'lucide-react';
+import { useState } from 'react';
 
 interface BookingHistoryProps {
-  user: any
+  user: any;
 }
 
 export function BookingHistory({ user }: BookingHistoryProps) {
-  const [filter, setFilter] = useState("all")
+  const [filter, setFilter] = useState('all');
 
   const bookingHistory = [
     {
       id: 1,
-      service: "Consulta Médica General",
-      professional: "Dr. Juan Pérez",
-      date: "2025-01-20",
-      time: "10:00",
-      location: "Clínica Centro",
-      price: "$150",
-      status: "confirmed",
-      description: "Consulta de rutina",
+      service: 'Consulta Médica General',
+      professional: 'Dr. Juan Pérez',
+      date: '2025-01-20',
+      time: '10:00',
+      location: 'Clínica Centro',
+      price: '$150',
+      status: 'confirmed',
+      description: 'Consulta de rutina',
       rating: 5,
-      notes: "Excelente atención, muy profesional",
+      notes: 'Excelente atención, muy profesional',
     },
     {
       id: 2,
-      service: "Terapia Física",
-      professional: "Lic. Ana Martínez",
-      date: "2025-01-22",
-      time: "14:30",
-      location: "Centro Rehabilitación",
-      price: "$200",
-      status: "pending",
-      description: "Sesión de rehabilitación",
+      service: 'Terapia Física',
+      professional: 'Lic. Ana Martínez',
+      date: '2025-01-22',
+      time: '14:30',
+      location: 'Centro Rehabilitación',
+      price: '$200',
+      status: 'pending',
+      description: 'Sesión de rehabilitación',
       rating: null,
-      notes: "",
+      notes: '',
     },
     {
       id: 3,
-      service: "Consulta Nutricional",
-      professional: "Nut. Carlos Ruiz",
-      date: "2025-01-18",
-      time: "09:00",
-      location: "Clínica Norte",
-      price: "$120",
-      status: "completed",
-      description: "Plan nutricional entregado",
+      service: 'Consulta Nutricional',
+      professional: 'Nut. Carlos Ruiz',
+      date: '2025-01-18',
+      time: '09:00',
+      location: 'Clínica Norte',
+      price: '$120',
+      status: 'completed',
+      description: 'Plan nutricional entregado',
       rating: 4,
-      notes: "Muy útil, plan personalizado",
+      notes: 'Muy útil, plan personalizado',
     },
     {
       id: 4,
-      service: "Examen de Laboratorio",
-      professional: "Lab. Central",
-      date: "2025-01-15",
-      time: "08:00",
-      location: "Laboratorio Central",
-      price: "$80",
-      status: "completed",
-      description: "Análisis de sangre completo",
+      service: 'Examen de Laboratorio',
+      professional: 'Lab. Central',
+      date: '2025-01-15',
+      time: '08:00',
+      location: 'Laboratorio Central',
+      price: '$80',
+      status: 'completed',
+      description: 'Análisis de sangre completo',
       rating: 5,
-      notes: "Resultados entregados a tiempo",
+      notes: 'Resultados entregados a tiempo',
     },
-  ]
+  ];
 
   const getStatusBadge = (status: string) => {
     switch (status) {
-      case "confirmed":
+      case 'confirmed':
         return (
-          <Badge className="bg-emerald-50 text-emerald-700 border-emerald-200 hover:bg-emerald-50">Confirmada</Badge>
-        )
-      case "pending":
-        return <Badge className="bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-50">Pendiente</Badge>
-      case "completed":
-        return <Badge className="bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-50">Completada</Badge>
+          <Badge className="bg-emerald-50 text-emerald-700 border-emerald-200 hover:bg-emerald-50">
+            Confirmada
+          </Badge>
+        );
+      case 'pending':
+        return (
+          <Badge className="bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-50">
+            Pendiente
+          </Badge>
+        );
+      case 'completed':
+        return (
+          <Badge className="bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-50">
+            Completada
+          </Badge>
+        );
       default:
-        return <Badge variant="outline">Desconocido</Badge>
+        return <Badge variant="outline">Desconocido</Badge>;
     }
-  }
+  };
 
   const renderStars = (rating: number | null) => {
-    if (!rating) return null
+    if (!rating) return null;
     return (
       <div className="flex items-center gap-1">
         {[...Array(5)].map((_, i) => (
-          <Star key={i} className={`w-4 h-4 ${i < rating ? "fill-yellow-400 text-yellow-400" : "text-gray-300"}`} />
+          <Star
+            key={i}
+            className={`w-4 h-4 ${
+              i < rating ? 'fill-yellow-400 text-yellow-400' : 'text-gray-300'
+            }`}
+          />
         ))}
         <span className="text-sm text-gray-600 ml-1">({rating})</span>
       </div>
-    )
-  }
+    );
+  };
 
   const filteredBookings = bookingHistory.filter((booking) => {
-    if (filter === "all") return true
-    return booking.status === filter
-  })
+    if (filter === 'all') return true;
+    return booking.status === filter;
+  });
 
   const stats = {
     total: bookingHistory.length,
-    completed: bookingHistory.filter((b) => b.status === "completed").length,
-    pending: bookingHistory.filter((b) => b.status === "pending").length,
-    confirmed: bookingHistory.filter((b) => b.status === "confirmed").length,
-  }
+    completed: bookingHistory.filter((b) => b.status === 'completed').length,
+    pending: bookingHistory.filter((b) => b.status === 'pending').length,
+    confirmed: bookingHistory.filter((b) => b.status === 'confirmed').length,
+  };
 
   return (
     <div className="space-y-8">
       {/* Header with Stats */}
       <div className="space-y-6">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Historial de Reservas</h1>
-          <p className="text-gray-600 mt-2">Revisa todas tus citas médicas anteriores</p>
+          <h1 className="text-3xl font-bold text-gray-900">
+            Historial de Reservas
+          </h1>
+          <p className="text-gray-600 mt-2">
+            Revisa todas tus reservas de servicios anteriores
+          </p>
         </div>
 
         {/* Stats Cards */}
@@ -124,7 +152,9 @@ export function BookingHistory({ user }: BookingHistoryProps) {
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm font-medium text-gray-600">Total</p>
-                  <p className="text-2xl font-bold text-gray-900">{stats.total}</p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    {stats.total}
+                  </p>
                 </div>
                 <FileText className="w-8 h-8 text-blue-500" />
               </div>
@@ -135,8 +165,12 @@ export function BookingHistory({ user }: BookingHistoryProps) {
             <CardContent className="p-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-gray-600">Completadas</p>
-                  <p className="text-2xl font-bold text-gray-900">{stats.completed}</p>
+                  <p className="text-sm font-medium text-gray-600">
+                    Completadas
+                  </p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    {stats.completed}
+                  </p>
                 </div>
                 <Calendar className="w-8 h-8 text-green-500" />
               </div>
@@ -147,8 +181,12 @@ export function BookingHistory({ user }: BookingHistoryProps) {
             <CardContent className="p-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-gray-600">Confirmadas</p>
-                  <p className="text-2xl font-bold text-gray-900">{stats.confirmed}</p>
+                  <p className="text-sm font-medium text-gray-600">
+                    Confirmadas
+                  </p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    {stats.confirmed}
+                  </p>
                 </div>
                 <Clock className="w-8 h-8 text-emerald-500" />
               </div>
@@ -159,8 +197,12 @@ export function BookingHistory({ user }: BookingHistoryProps) {
             <CardContent className="p-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-gray-600">Pendientes</p>
-                  <p className="text-2xl font-bold text-gray-900">{stats.pending}</p>
+                  <p className="text-sm font-medium text-gray-600">
+                    Pendientes
+                  </p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    {stats.pending}
+                  </p>
                 </div>
                 <User className="w-8 h-8 text-amber-500" />
               </div>
@@ -174,18 +216,22 @@ export function BookingHistory({ user }: BookingHistoryProps) {
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <Filter className="w-4 h-4 text-gray-500" />
-                <span className="text-sm font-medium text-gray-700">Filtrar por estado:</span>
+                <span className="text-sm font-medium text-gray-700">
+                  Filtrar por estado:
+                </span>
               </div>
               <div className="flex gap-2">
                 {[
-                  { key: "all", label: "Todas" },
-                  { key: "completed", label: "Completadas" },
-                  { key: "confirmed", label: "Confirmadas" },
-                  { key: "pending", label: "Pendientes" },
+                  { key: 'all', label: 'Todas' },
+                  { key: 'completed', label: 'Completadas' },
+                  { key: 'confirmed', label: 'Confirmadas' },
+                  { key: 'pending', label: 'Pendientes' },
                 ].map((filterOption) => (
                   <Button
                     key={filterOption.key}
-                    variant={filter === filterOption.key ? "default" : "outline"}
+                    variant={
+                      filter === filterOption.key ? 'default' : 'outline'
+                    }
                     size="sm"
                     onClick={() => setFilter(filterOption.key)}
                     className="text-xs"
@@ -202,7 +248,10 @@ export function BookingHistory({ user }: BookingHistoryProps) {
       {/* Booking History List */}
       <div className="space-y-4">
         {filteredBookings.map((booking) => (
-          <Card key={booking.id} className="hover:shadow-md transition-shadow duration-200">
+          <Card
+            key={booking.id}
+            className="hover:shadow-md transition-shadow duration-200"
+          >
             <CardContent className="p-6">
               <div className="flex items-start gap-6">
                 {/* Icon */}
@@ -214,12 +263,22 @@ export function BookingHistory({ user }: BookingHistoryProps) {
                 <div className="flex-1 space-y-3">
                   <div className="flex items-start justify-between">
                     <div className="space-y-1">
-                      <h3 className="text-lg font-semibold text-gray-900">{booking.service}</h3>
-                      <p className="text-gray-600 font-medium">{booking.professional}</p>
-                      {booking.description && <p className="text-sm text-gray-500">{booking.description}</p>}
+                      <h3 className="text-lg font-semibold text-gray-900">
+                        {booking.service}
+                      </h3>
+                      <p className="text-gray-600 font-medium">
+                        {booking.professional}
+                      </p>
+                      {booking.description && (
+                        <p className="text-sm text-gray-500">
+                          {booking.description}
+                        </p>
+                      )}
                     </div>
                     <div className="text-right space-y-2">
-                      <div className="text-xl font-bold text-gray-900">{booking.price}</div>
+                      <div className="text-xl font-bold text-gray-900">
+                        {booking.price}
+                      </div>
                       {getStatusBadge(booking.status)}
                     </div>
                   </div>
@@ -243,20 +302,26 @@ export function BookingHistory({ user }: BookingHistoryProps) {
                   </div>
 
                   {/* Rating and Notes */}
-                  {booking.status === "completed" && (
+                  {booking.status === 'completed' && (
                     <>
                       <Separator />
                       <div className="space-y-2">
                         {booking.rating && (
                           <div className="flex items-center gap-2">
-                            <span className="text-sm font-medium text-gray-700">Calificación:</span>
+                            <span className="text-sm font-medium text-gray-700">
+                              Calificación:
+                            </span>
                             {renderStars(booking.rating)}
                           </div>
                         )}
                         {booking.notes && (
                           <div className="flex items-start gap-2">
-                            <span className="text-sm font-medium text-gray-700">Notas:</span>
-                            <p className="text-sm text-gray-600">{booking.notes}</p>
+                            <span className="text-sm font-medium text-gray-700">
+                              Notas:
+                            </span>
+                            <p className="text-sm text-gray-600">
+                              {booking.notes}
+                            </p>
                           </div>
                         )}
                       </div>
@@ -269,7 +334,7 @@ export function BookingHistory({ user }: BookingHistoryProps) {
                       <Download className="w-4 h-4 mr-2" />
                       Descargar Recibo
                     </Button>
-                    {booking.status === "completed" && !booking.rating && (
+                    {booking.status === 'completed' && !booking.rating && (
                       <Button variant="outline" size="sm">
                         <Star className="w-4 h-4 mr-2" />
                         Calificar
@@ -287,11 +352,15 @@ export function BookingHistory({ user }: BookingHistoryProps) {
         <Card>
           <CardContent className="p-12 text-center">
             <FileText className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-gray-900 mb-2">No hay reservas</h3>
-            <p className="text-gray-600">No se encontraron reservas con el filtro seleccionado.</p>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              No hay reservas
+            </h3>
+            <p className="text-gray-600">
+              No se encontraron reservas con el filtro seleccionado.
+            </p>
           </CardContent>
         </Card>
       )}
     </div>
-  )
+  );
 }

--- a/components/client/client-dashboard.tsx
+++ b/components/client/client-dashboard.tsx
@@ -1,17 +1,17 @@
-"use client"
+'use client';
 
-import { useEffect } from "react"
-import { ClientHeader } from "./client-header"
-import { ClientNavigation } from "./client-navigation"
-import { ClientDashboardView } from "./dashboard/client-dashboard-view"
-import { MyBookings } from "./my-bookings"
-import { BookingHistory } from "./booking-history"
-import { MyProfile } from "./my-profile"
-import { useClientStore } from "@/lib/stores/client-store"
-import { useAuthStore } from "@/lib/stores/auth-store"
+import { useEffect } from 'react';
+import { ClientHeader } from './client-header';
+import { ClientNavigation } from './client-navigation';
+import { ClientDashboardView } from './dashboard/client-dashboard-view';
+import { MyBookings } from './my-bookings';
+import { BookingHistory } from './booking-history';
+import MyProfile from './my-profile';
+import { useClientStore } from '@/lib/stores/client-store';
+import { useAuthStore } from '@/lib/stores/auth-store';
 
 export function ClientDashboard() {
-  const { signOut } = useAuthStore()
+  const { profile } = useAuthStore();
   const {
     upcomingBookings,
     availableServices,
@@ -22,43 +22,27 @@ export function ClientDashboard() {
     updateBookingStatus,
     cancelBooking,
     loadData,
-  } = useClientStore()
+  } = useClientStore();
 
   // Load mock data on mount
   useEffect(() => {
     if (upcomingBookings.length === 0) {
-      loadData()
+      loadData();
     }
-  }, [upcomingBookings.length, loadData])
-
-  // Helpers
-  // const upcomingBookings = getUpcomingBookings()
-  // const bookingHistory = getBookingHistory()
+  }, [upcomingBookings.length, loadData]);
 
   return (
     <div className="flex min-h-screen flex-col">
-      <ClientHeader onLogout={signOut} />
+      <ClientHeader />
       <div className="flex flex-1">
-        <ClientNavigation activeTab={activeTab} onTabChange={setActiveTab} />
+        <ClientNavigation />
         <main className="flex-1 overflow-y-auto bg-gray-50 p-6">
-          {activeTab === "dashboard" && (
-            <ClientDashboardView
-              upcomingBookings={upcomingBookings}
-              availableServices={availableServices}
-              onBookService={addBooking}
-            />
-          )}
-          {activeTab === "bookings" && (
-            <MyBookings
-              bookings={upcomingBookings}
-              onUpdateBooking={updateBookingStatus}
-              onCancelBooking={cancelBooking}
-            />
-          )}
-          {activeTab === "history" && <BookingHistory bookings={bookingHistory} />}
-          {activeTab === "profile" && <MyProfile />}
+          {activeTab === 'dashboard' && <ClientDashboardView />}
+          {activeTab === 'bookings' && <MyBookings user={profile} />}
+          {activeTab === 'history' && <BookingHistory user={profile} />}
+          {activeTab === 'profile' && <MyProfile />}
         </main>
       </div>
     </div>
-  )
+  );
 }

--- a/components/client/client-navigation.tsx
+++ b/components/client/client-navigation.tsx
@@ -1,57 +1,58 @@
-"use client"
+'use client';
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { Calendar, History, User, Home } from "lucide-react"
-import { useClientStore } from "@/lib/stores/client-store"
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Calendar, History, User, Home } from 'lucide-react';
+import { useClientStore } from '@/lib/stores/client-store';
 
 const navigationItems = [
   {
-    id: "dashboard" as const,
-    label: "Dashboard",
+    id: 'dashboard' as const,
+    label: 'Dashboard',
     icon: Home,
   },
   {
-    id: "bookings" as const,
-    label: "Mis Citas",
+    id: 'bookings' as const,
+    label: 'Mis Reservas',
     icon: Calendar,
   },
   {
-    id: "history" as const,
-    label: "Historial",
+    id: 'history' as const,
+    label: 'Historial',
     icon: History,
   },
   {
-    id: "profile" as const,
-    label: "Perfil",
+    id: 'profile' as const,
+    label: 'Perfil',
     icon: User,
   },
-]
+];
 
 export function ClientNavigation() {
-  const { activeTab, setActiveTab } = useClientStore()
+  const { activeTab, setActiveTab } = useClientStore();
 
   return (
     <nav className="w-64 bg-white border-r min-h-screen p-4">
       <div className="space-y-2">
         {navigationItems.map((item) => {
-          const Icon = item.icon
+          const Icon = item.icon;
           return (
             <Button
               key={item.id}
-              variant={activeTab === item.id ? "default" : "ghost"}
+              variant={activeTab === item.id ? 'default' : 'ghost'}
               className={cn(
-                "w-full justify-start gap-2",
-                activeTab === item.id && "bg-blue-600 text-white hover:bg-blue-700",
+                'w-full justify-start gap-2',
+                activeTab === item.id &&
+                  'bg-blue-600 text-white hover:bg-blue-700'
               )}
               onClick={() => setActiveTab(item.id)}
             >
               <Icon className="h-4 w-4" />
               {item.label}
             </Button>
-          )
+          );
         })}
       </div>
     </nav>
-  )
+  );
 }

--- a/components/client/dashboard/client-dashboard-view.tsx
+++ b/components/client/dashboard/client-dashboard-view.tsx
@@ -1,173 +1,198 @@
-"use client"
+'use client';
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Calendar, Clock, MapPin, User, Scissors, Plus, ArrowRight, Star, CheckCircle, Briefcase } from "lucide-react"
-import { useClientStore } from "@/lib/stores/client-store"
-import { useAuthStore } from "@/lib/stores/auth-store"
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Calendar,
+  Clock,
+  MapPin,
+  User,
+  Scissors,
+  Plus,
+  ArrowRight,
+  Star,
+  CheckCircle,
+  Briefcase,
+} from 'lucide-react';
+import { useClientStore } from '@/lib/stores/client-store';
+import { useAuthStore } from '@/lib/stores/auth-store';
 
 export function ClientDashboardView() {
-  const { setActiveTab } = useClientStore()
-  const { profile } = useAuthStore()
+  const { setActiveTab } = useClientStore();
+  const { profile } = useAuthStore();
 
   const handleNewBooking = () => {
-    setActiveTab("bookings")
-  }
+    setActiveTab('bookings');
+  };
 
   const handleViewBookings = () => {
-    setActiveTab("bookings")
-  }
+    setActiveTab('bookings');
+  };
 
   // Mock data - en producción vendría del store o API
   const stats = [
     {
-      title: "Citas Completadas",
-      value: "12",
-      change: "+2 este mes",
+      title: 'Reservas Completadas',
+      value: '12',
+      change: '+2 este mes',
       icon: CheckCircle,
-      gradient: "from-green-500 to-emerald-600",
-      bgGradient: "from-green-50 to-emerald-50",
+      gradient: 'from-green-500 to-emerald-600',
+      bgGradient: 'from-green-50 to-emerald-50',
     },
     {
-      title: "Próximas Citas",
-      value: "3",
-      change: "Esta semana",
+      title: 'Próximas Reservas',
+      value: '3',
+      change: 'Esta semana',
       icon: Calendar,
-      gradient: "from-blue-500 to-cyan-600",
-      bgGradient: "from-blue-50 to-cyan-50",
+      gradient: 'from-blue-500 to-cyan-600',
+      bgGradient: 'from-blue-50 to-cyan-50',
     },
     {
-      title: "Profesionales",
-      value: "5",
-      change: "Favoritos",
+      title: 'Profesionales',
+      value: '5',
+      change: 'Favoritos',
       icon: User,
-      gradient: "from-purple-500 to-violet-600",
-      bgGradient: "from-purple-50 to-violet-50",
+      gradient: 'from-purple-500 to-violet-600',
+      bgGradient: 'from-purple-50 to-violet-50',
     },
     {
-      title: "Servicios Usados",
-      value: "8",
-      change: "Diferentes",
+      title: 'Servicios Usados',
+      value: '8',
+      change: 'Diferentes',
       icon: Briefcase,
-      gradient: "from-orange-500 to-amber-600",
-      bgGradient: "from-orange-50 to-amber-50",
+      gradient: 'from-orange-500 to-amber-600',
+      bgGradient: 'from-orange-50 to-amber-50',
     },
-  ]
+  ];
 
-  const upcomingAppointments = [
+  const upcomingBookings = [
     {
       id: 1,
-      service: "Corte de Cabello",
-      professional: "María González",
-      date: "2024-01-15",
-      time: "10:00",
-      location: "Salón Central",
-      status: "confirmed",
-      avatar: "/placeholder-user.jpg",
+      service: 'Corte de Cabello',
+      professional: 'María González',
+      date: '2024-01-15',
+      time: '10:00',
+      location: 'Salón Central',
+      status: 'confirmed',
+      avatar: '/placeholder-user.jpg',
     },
     {
       id: 2,
-      service: "Manicure",
-      professional: "Carlos Ruiz",
-      date: "2024-01-18",
-      time: "14:30",
-      location: "Spa Norte",
-      status: "pending",
-      avatar: "/placeholder-user.jpg",
+      service: 'Manicure',
+      professional: 'Carlos Ruiz',
+      date: '2024-01-18',
+      time: '14:30',
+      location: 'Spa Norte',
+      status: 'pending',
+      avatar: '/placeholder-user.jpg',
     },
     {
       id: 3,
-      service: "Masaje Relajante",
-      professional: "Ana Martín",
-      date: "2024-01-20",
-      time: "16:00",
-      location: "Centro de Bienestar",
-      status: "confirmed",
-      avatar: "/placeholder-user.jpg",
+      service: 'Masaje Relajante',
+      professional: 'Ana Martín',
+      date: '2024-01-20',
+      time: '16:00',
+      location: 'Centro de Bienestar',
+      status: 'confirmed',
+      avatar: '/placeholder-user.jpg',
     },
-  ]
+  ];
 
   const featuredServices = [
     {
-      name: "Peluquería",
-      description: "Cortes y peinados profesionales",
-      icon: "✂️",
-      gradient: "from-pink-500 to-rose-600",
+      name: 'Peluquería',
+      description: 'Cortes y peinados profesionales',
+      icon: '✂️',
+      gradient: 'from-pink-500 to-rose-600',
       professionals: 8,
       rating: 4.9,
     },
     {
-      name: "Spa & Bienestar",
-      description: "Relajación y cuidado personal",
-      icon: "🧘‍♀️",
-      gradient: "from-purple-500 to-indigo-600",
+      name: 'Spa & Bienestar',
+      description: 'Relajación y cuidado personal',
+      icon: '🧘‍♀️',
+      gradient: 'from-purple-500 to-indigo-600',
       professionals: 6,
       rating: 4.8,
     },
     {
-      name: "Estética",
-      description: "Tratamientos de belleza",
-      icon: "💅",
-      gradient: "from-blue-500 to-cyan-600",
+      name: 'Estética',
+      description: 'Tratamientos de belleza',
+      icon: '💅',
+      gradient: 'from-blue-500 to-cyan-600',
       professionals: 5,
       rating: 4.9,
     },
     {
-      name: "Fitness",
-      description: "Entrenamiento personalizado",
-      icon: "💪",
-      gradient: "from-green-500 to-teal-600",
+      name: 'Fitness',
+      description: 'Entrenamiento personalizado',
+      icon: '💪',
+      gradient: 'from-green-500 to-teal-600',
       professionals: 12,
       rating: 4.7,
     },
     {
-      name: "Consultoría",
-      description: "Asesoramiento profesional",
-      icon: "💼",
-      gradient: "from-orange-500 to-red-600",
+      name: 'Consultoría',
+      description: 'Asesoramiento profesional',
+      icon: '💼',
+      gradient: 'from-orange-500 to-red-600',
       professionals: 4,
       rating: 4.8,
     },
     {
-      name: "Educación",
-      description: "Clases y tutorías",
-      icon: "📚",
-      gradient: "from-indigo-500 to-purple-600",
+      name: 'Educación',
+      description: 'Clases y tutorías',
+      icon: '📚',
+      gradient: 'from-indigo-500 to-purple-600',
       professionals: 7,
       rating: 4.9,
     },
-  ]
+  ];
 
   const getStatusBadge = (status: string) => {
     switch (status) {
-      case "confirmed":
-        return <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Confirmada</Badge>
-      case "pending":
-        return <Badge className="bg-yellow-100 text-yellow-800 hover:bg-yellow-100">Pendiente</Badge>
-      case "cancelled":
-        return <Badge className="bg-red-100 text-red-800 hover:bg-red-100">Cancelada</Badge>
+      case 'confirmed':
+        return (
+          <Badge className="bg-green-100 text-green-800 hover:bg-green-100">
+            Confirmada
+          </Badge>
+        );
+      case 'pending':
+        return (
+          <Badge className="bg-yellow-100 text-yellow-800 hover:bg-yellow-100">
+            Pendiente
+          </Badge>
+        );
+      case 'cancelled':
+        return (
+          <Badge className="bg-red-100 text-red-800 hover:bg-red-100">
+            Cancelada
+          </Badge>
+        );
       default:
-        return <Badge variant="secondary">Desconocido</Badge>
+        return <Badge variant="secondary">Desconocido</Badge>;
     }
-  }
+  };
 
   const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
+    const date = new Date(dateString);
     return {
-      day: date.getDate().toString().padStart(2, "0"),
-      month: date.toLocaleDateString("es-ES", { month: "short" }).toUpperCase(),
-      weekday: date.toLocaleDateString("es-ES", { weekday: "short" }).toUpperCase(),
-    }
-  }
+      day: date.getDate().toString().padStart(2, '0'),
+      month: date.toLocaleDateString('es-ES', { month: 'short' }).toUpperCase(),
+      weekday: date
+        .toLocaleDateString('es-ES', { weekday: 'short' })
+        .toUpperCase(),
+    };
+  };
 
   const getGreeting = () => {
-    const hour = new Date().getHours()
-    if (hour < 12) return "Buenos días"
-    if (hour < 18) return "Buenas tardes"
-    return "Buenas noches"
-  }
+    const hour = new Date().getHours();
+    if (hour < 12) return 'Buenos días';
+    if (hour < 18) return 'Buenas tardes';
+    return 'Buenas noches';
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
@@ -182,16 +207,19 @@ export function ClientDashboardView() {
         <div className="relative px-6 py-12">
           <div className="max-w-4xl">
             <h1 className="text-4xl font-bold mb-2">
-              {getGreeting()}, {profile?.full_name?.split(" ")[0] || "Usuario"} 👋
+              {getGreeting()}, {profile?.full_name?.split(' ')[0] || 'Usuario'}{' '}
+              👋
             </h1>
-            <p className="text-xl text-blue-100 mb-8">Encuentra y agenda servicios con los mejores profesionales</p>
+            <p className="text-xl text-blue-100 mb-8">
+              Encuentra y agenda servicios con los mejores profesionales
+            </p>
             <Button
               onClick={handleNewBooking}
               size="lg"
               className="bg-white text-blue-600 hover:bg-blue-50 hover:text-blue-700 font-semibold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105"
             >
               <Plus className="mr-2 h-5 w-5" />
-              Nueva Cita
+              Nueva Reserva
             </Button>
           </div>
         </div>
@@ -201,7 +229,7 @@ export function ClientDashboardView() {
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {stats.map((stat, index) => {
-            const IconComponent = stat.icon
+            const IconComponent = stat.icon;
             return (
               <Card
                 key={index}
@@ -210,28 +238,36 @@ export function ClientDashboardView() {
                 <CardContent className="p-6">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-sm font-medium text-gray-600 mb-1">{stat.title}</p>
-                      <p className="text-3xl font-bold text-gray-900">{stat.value}</p>
-                      <p className="text-xs text-gray-500 mt-1">{stat.change}</p>
+                      <p className="text-sm font-medium text-gray-600 mb-1">
+                        {stat.title}
+                      </p>
+                      <p className="text-3xl font-bold text-gray-900">
+                        {stat.value}
+                      </p>
+                      <p className="text-xs text-gray-500 mt-1">
+                        {stat.change}
+                      </p>
                     </div>
-                    <div className={`p-3 rounded-full bg-gradient-to-r ${stat.gradient} shadow-lg`}>
+                    <div
+                      className={`p-3 rounded-full bg-gradient-to-r ${stat.gradient} shadow-lg`}
+                    >
                       <IconComponent className="h-6 w-6 text-white" />
                     </div>
                   </div>
                 </CardContent>
               </Card>
-            )
+            );
           })}
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-1 gap-8">
-          {/* Upcoming Appointments */}
+          {/* Upcoming Bookings */}
           <Card className="shadow-lg border-0 bg-white/70 backdrop-blur-sm">
             <CardHeader className="pb-4">
               <div className="flex items-center justify-between">
                 <CardTitle className="text-xl font-bold text-gray-900 flex items-center gap-2">
                   <Calendar className="h-5 w-5 text-blue-600" />
-                  Próximas Citas
+                  Próximas Reservas
                 </CardTitle>
                 <Button
                   variant="ghost"
@@ -244,66 +280,77 @@ export function ClientDashboardView() {
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
-              {upcomingAppointments.length === 0 ? (
+              {upcomingBookings.length === 0 ? (
                 <div className="text-center py-12">
                   <div className="bg-gray-100 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
                     <Calendar className="h-8 w-8 text-gray-400" />
                   </div>
-                  <p className="text-gray-500 text-lg mb-2">No tienes citas programadas</p>
-                  <p className="text-gray-400 text-sm mb-4">¡Es un buen momento para agendar una!</p>
+                  <p className="text-gray-500 text-lg mb-2">
+                    No tienes reservas programadas
+                  </p>
+                  <p className="text-gray-400 text-sm mb-4">
+                    ¡Es un buen momento para hacer una reserva!
+                  </p>
                   <Button
                     onClick={handleNewBooking}
                     className="bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700"
                   >
                     <Plus className="mr-2 h-4 w-4" />
-                    Agendar Cita
+                    Nueva Reserva
                   </Button>
                 </div>
               ) : (
-                upcomingAppointments.map((appointment) => {
-                  const dateInfo = formatDate(appointment.date)
+                upcomingBookings.map((booking) => {
+                  const dateInfo = formatDate(booking.date);
                   return (
                     <div
-                      key={appointment.id}
+                      key={booking.id}
                       className="flex items-center gap-4 p-4 rounded-xl bg-gradient-to-r from-white to-gray-50 border border-gray-100 hover:shadow-md transition-all duration-300 hover:scale-[1.02]"
                     >
                       <div className="flex-shrink-0">
                         <div className="w-16 h-16 rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 flex flex-col items-center justify-center text-white shadow-lg">
-                          <span className="text-lg font-bold">{dateInfo.day}</span>
+                          <span className="text-lg font-bold">
+                            {dateInfo.day}
+                          </span>
                           <span className="text-xs">{dateInfo.month}</span>
                         </div>
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-1">
-                          <h3 className="font-semibold text-gray-900 truncate">{appointment.service}</h3>
-                          {getStatusBadge(appointment.status)}
+                          <h3 className="font-semibold text-gray-900 truncate">
+                            {booking.service}
+                          </h3>
+                          {getStatusBadge(booking.status)}
                         </div>
                         <div className="flex items-center gap-4 text-sm text-gray-600">
                           <div className="flex items-center gap-1">
                             <User className="h-4 w-4" />
-                            <span>{appointment.professional}</span>
+                            <span>{booking.professional}</span>
                           </div>
                           <div className="flex items-center gap-1">
                             <Clock className="h-4 w-4" />
-                            <span>{appointment.time}</span>
+                            <span>{booking.time}</span>
                           </div>
                           <div className="flex items-center gap-1">
                             <MapPin className="h-4 w-4" />
-                            <span className="truncate">{appointment.location}</span>
+                            <span className="truncate">{booking.location}</span>
                           </div>
                         </div>
                       </div>
                       <Avatar className="h-10 w-10 ring-2 ring-blue-100">
-                        <AvatarImage src={appointment.avatar || "/placeholder.svg"} alt={appointment.professional} />
+                        <AvatarImage
+                          src={booking.avatar || '/placeholder.svg'}
+                          alt={booking.professional}
+                        />
                         <AvatarFallback className="bg-gradient-to-br from-blue-500 to-indigo-600 text-white">
-                          {appointment.professional
-                            .split(" ")
+                          {booking.professional
+                            .split(' ')
                             .map((n) => n[0])
-                            .join("")}
+                            .join('')}
                         </AvatarFallback>
                       </Avatar>
                     </div>
-                  )
+                  );
                 })
               )}
             </CardContent>
@@ -330,7 +377,9 @@ export function ClientDashboardView() {
                   </div>
                   <div className="space-y-3">
                     <h3 className="font-bold text-lg">{service.name}</h3>
-                    <p className="text-sm text-white/90 leading-relaxed">{service.description}</p>
+                    <p className="text-sm text-white/90 leading-relaxed">
+                      {service.description}
+                    </p>
                     <div className="flex items-center justify-between text-xs text-white/80">
                       <span>{service.professionals} profesionales</span>
                       <div className="flex items-center gap-1">
@@ -354,5 +403,5 @@ export function ClientDashboardView() {
         </Card>
       </div>
     </div>
-  )
+  );
 }

--- a/components/client/my-bookings.tsx
+++ b/components/client/my-bookings.tsx
@@ -1,10 +1,10 @@
-"use client"
+'use client';
 
-import { useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Separator } from "@/components/ui/separator"
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
 import {
   Calendar,
   Clock,
@@ -16,85 +16,85 @@ import {
   Timer,
   Phone,
   MessageSquare,
-} from "lucide-react"
-import { NewBookingModal } from "./new-booking-modal"
+} from 'lucide-react';
+import { NewBookingModal } from './new-booking-modal';
 
 interface MyBookingsProps {
-  user: any
+  user: any;
 }
 
 export function MyBookings({ user }: MyBookingsProps) {
-  const [showNewBooking, setShowNewBooking] = useState(false)
+  const [showNewBooking, setShowNewBooking] = useState(false);
 
   const stats = [
     {
-      label: "Próximas",
-      value: "2",
+      label: 'Próximas',
+      value: '2',
       icon: Calendar,
-      color: "text-blue-600",
-      bgColor: "bg-blue-50",
-      borderColor: "border-l-blue-500",
+      color: 'text-blue-600',
+      bgColor: 'bg-blue-50',
+      borderColor: 'border-l-blue-500',
     },
     {
-      label: "Pendientes",
-      value: "1",
+      label: 'Pendientes',
+      value: '1',
       icon: Timer,
-      color: "text-amber-600",
-      bgColor: "bg-amber-50",
-      borderColor: "border-l-amber-500",
+      color: 'text-amber-600',
+      bgColor: 'bg-amber-50',
+      borderColor: 'border-l-amber-500',
     },
     {
-      label: "Completadas",
-      value: "1",
+      label: 'Completadas',
+      value: '1',
       icon: CheckCircle,
-      color: "text-emerald-600",
-      bgColor: "bg-emerald-50",
-      borderColor: "border-l-emerald-500",
+      color: 'text-emerald-600',
+      bgColor: 'bg-emerald-50',
+      borderColor: 'border-l-emerald-500',
     },
     {
-      label: "Total",
-      value: "4",
+      label: 'Total',
+      value: '4',
       icon: User,
-      color: "text-gray-600",
-      bgColor: "bg-gray-50",
-      borderColor: "border-l-gray-500",
+      color: 'text-gray-600',
+      bgColor: 'bg-gray-50',
+      borderColor: 'border-l-gray-500',
     },
-  ]
+  ];
 
   const upcomingBookings = [
     {
       id: 1,
-      service: "Consulta Médica General",
-      professional: "Dr. Juan Pérez",
-      date: "2025-01-20",
-      time: "10:00",
-      location: "Clínica Centro",
-      price: "$150",
-      duration: "30 min",
-      status: "confirmed",
-      specialty: "Medicina General",
-      phone: "+1 234 567 8900",
-      instructions: "Traer estudios previos si los tiene",
+      service: 'Corte y Peinado',
+      professional: 'Ana Martínez',
+      date: '2025-01-20',
+      time: '10:00',
+      location: 'Salón de Belleza Central',
+      price: '$45',
+      duration: '60 min',
+      status: 'confirmed',
+      specialty: 'Estilismo',
+      phone: '+1 234 567 8900',
+      instructions: 'Traer foto de referencia del corte deseado',
     },
     {
       id: 2,
-      service: "Terapia Física",
-      professional: "Lic. Ana Martínez",
-      date: "2025-01-22",
-      time: "14:30",
-      location: "Centro Rehabilitación",
-      price: "$200",
-      duration: "60 min",
-      status: "pending",
-      specialty: "Fisioterapia",
-      phone: "+1 234 567 8901",
-      instructions: "Usar ropa cómoda para ejercicios",
+      service: 'Masaje Relajante',
+      professional: 'Lic. Carlos Ruiz',
+      date: '2025-01-22',
+      time: '14:30',
+      location: 'Spa Wellness',
+      price: '$85',
+      duration: '90 min',
+      status: 'pending',
+      specialty: 'Terapia de Masajes',
+      phone: '+1 234 567 8901',
+      instructions: 'Llegar 15 minutos antes para relajarse',
     },
-  ]
+  ];
 
   const getStatusInfo = (status: string) => {
     switch (status) {
-      case "confirmed":
+      case 'confirmed':
         return {
           badge: (
             <Badge className="bg-emerald-50 text-emerald-700 border-emerald-200 hover:bg-emerald-50">
@@ -103,9 +103,9 @@ export function MyBookings({ user }: MyBookingsProps) {
             </Badge>
           ),
           icon: <CheckCircle className="w-5 h-5 text-emerald-600" />,
-          color: "text-emerald-600",
-        }
-      case "pending":
+          color: 'text-emerald-600',
+        };
+      case 'pending':
         return {
           badge: (
             <Badge className="bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-50">
@@ -114,16 +114,16 @@ export function MyBookings({ user }: MyBookingsProps) {
             </Badge>
           ),
           icon: <Timer className="w-5 h-5 text-amber-600" />,
-          color: "text-amber-600",
-        }
+          color: 'text-amber-600',
+        };
       default:
         return {
           badge: <Badge variant="outline">Desconocido</Badge>,
           icon: <AlertCircle className="w-5 h-5 text-gray-600" />,
-          color: "text-gray-600",
-        }
+          color: 'text-gray-600',
+        };
     }
-  }
+  };
 
   return (
     <div className="space-y-8">
@@ -132,7 +132,9 @@ export function MyBookings({ user }: MyBookingsProps) {
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <h1 className="text-3xl font-bold text-gray-900">Mis Reservas</h1>
-            <p className="text-gray-600 mt-2">Gestiona tus citas médicas programadas</p>
+            <p className="text-gray-600 mt-2">
+              Gestiona tus reservas de servicios
+            </p>
           </div>
           <Button
             onClick={() => setShowNewBooking(true)}
@@ -147,12 +149,19 @@ export function MyBookings({ user }: MyBookingsProps) {
         {/* Stats */}
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
           {stats.map((stat) => (
-            <Card key={stat.label} className={`border-l-4 ${stat.borderColor} hover:shadow-md transition-shadow`}>
+            <Card
+              key={stat.label}
+              className={`border-l-4 ${stat.borderColor} hover:shadow-md transition-shadow`}
+            >
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm font-medium text-gray-600">{stat.label}</p>
-                    <p className="text-3xl font-bold text-gray-900 mt-1">{stat.value}</p>
+                    <p className="text-sm font-medium text-gray-600">
+                      {stat.label}
+                    </p>
+                    <p className="text-3xl font-bold text-gray-900 mt-1">
+                      {stat.value}
+                    </p>
                   </div>
                   <div className={`p-3 rounded-xl ${stat.bgColor}`}>
                     <stat.icon className={`w-6 h-6 ${stat.color}`} />
@@ -168,16 +177,23 @@ export function MyBookings({ user }: MyBookingsProps) {
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-2xl font-semibold text-gray-900">Próximas Citas</h2>
-            <p className="text-gray-600">Tus citas programadas para los próximos días</p>
+            <h2 className="text-2xl font-semibold text-gray-900">
+              Próximas Reservas
+            </h2>
+            <p className="text-gray-600">
+              Tus reservas programadas para los próximos días
+            </p>
           </div>
         </div>
 
         <div className="space-y-6">
           {upcomingBookings.map((booking) => {
-            const statusInfo = getStatusInfo(booking.status)
+            const statusInfo = getStatusInfo(booking.status);
             return (
-              <Card key={booking.id} className="hover:shadow-lg transition-all duration-200 border-0 shadow-md">
+              <Card
+                key={booking.id}
+                className="hover:shadow-lg transition-all duration-200 border-0 shadow-md"
+              >
                 <CardContent className="p-8">
                   <div className="flex items-start gap-6">
                     {/* Status Icon */}
@@ -190,15 +206,25 @@ export function MyBookings({ user }: MyBookingsProps) {
                       {/* Header */}
                       <div className="flex items-start justify-between">
                         <div className="space-y-2">
-                          <h3 className="text-xl font-bold text-gray-900">{booking.service}</h3>
+                          <h3 className="text-xl font-bold text-gray-900">
+                            {booking.service}
+                          </h3>
                           <div className="space-y-1">
-                            <p className="text-lg text-gray-700 font-medium">{booking.professional}</p>
-                            <p className="text-sm text-gray-500">{booking.specialty}</p>
+                            <p className="text-lg text-gray-700 font-medium">
+                              {booking.professional}
+                            </p>
+                            <p className="text-sm text-gray-500">
+                              {booking.specialty}
+                            </p>
                           </div>
                         </div>
                         <div className="text-right space-y-2">
-                          <div className="text-2xl font-bold text-gray-900">{booking.price}</div>
-                          <div className="text-sm text-gray-500">{booking.duration}</div>
+                          <div className="text-2xl font-bold text-gray-900">
+                            {booking.price}
+                          </div>
+                          <div className="text-sm text-gray-500">
+                            {booking.duration}
+                          </div>
                           {statusInfo.badge}
                         </div>
                       </div>
@@ -210,24 +236,36 @@ export function MyBookings({ user }: MyBookingsProps) {
                         <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
                           <Calendar className="w-5 h-5 text-blue-600" />
                           <div>
-                            <p className="text-xs text-gray-500 uppercase tracking-wide">Fecha</p>
-                            <p className="font-medium text-gray-900">{booking.date}</p>
+                            <p className="text-xs text-gray-500 uppercase tracking-wide">
+                              Fecha
+                            </p>
+                            <p className="font-medium text-gray-900">
+                              {booking.date}
+                            </p>
                           </div>
                         </div>
 
                         <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
                           <Clock className="w-5 h-5 text-green-600" />
                           <div>
-                            <p className="text-xs text-gray-500 uppercase tracking-wide">Hora</p>
-                            <p className="font-medium text-gray-900">{booking.time}</p>
+                            <p className="text-xs text-gray-500 uppercase tracking-wide">
+                              Hora
+                            </p>
+                            <p className="font-medium text-gray-900">
+                              {booking.time}
+                            </p>
                           </div>
                         </div>
 
                         <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
                           <MapPin className="w-5 h-5 text-red-600" />
                           <div>
-                            <p className="text-xs text-gray-500 uppercase tracking-wide">Ubicación</p>
-                            <p className="font-medium text-gray-900">{booking.location}</p>
+                            <p className="text-xs text-gray-500 uppercase tracking-wide">
+                              Ubicación
+                            </p>
+                            <p className="font-medium text-gray-900">
+                              {booking.location}
+                            </p>
                           </div>
                         </div>
                       </div>
@@ -235,8 +273,12 @@ export function MyBookings({ user }: MyBookingsProps) {
                       {/* Instructions */}
                       {booking.instructions && (
                         <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
-                          <p className="text-sm font-medium text-blue-900 mb-1">Instrucciones:</p>
-                          <p className="text-sm text-blue-800">{booking.instructions}</p>
+                          <p className="text-sm font-medium text-blue-900 mb-1">
+                            Instrucciones:
+                          </p>
+                          <p className="text-sm text-blue-800">
+                            {booking.instructions}
+                          </p>
                         </div>
                       )}
 
@@ -245,18 +287,26 @@ export function MyBookings({ user }: MyBookingsProps) {
                       {/* Actions */}
                       <div className="flex items-center justify-between">
                         <div className="flex items-center gap-3">
-                          <Button variant="outline" size="sm" className="flex items-center gap-2 bg-transparent">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="flex items-center gap-2 bg-transparent"
+                          >
                             <Phone className="w-4 h-4" />
                             Llamar
                           </Button>
-                          <Button variant="outline" size="sm" className="flex items-center gap-2 bg-transparent">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="flex items-center gap-2 bg-transparent"
+                          >
                             <MessageSquare className="w-4 h-4" />
                             Mensaje
                           </Button>
                         </div>
 
                         <div className="flex items-center gap-2">
-                          {booking.status === "confirmed" && (
+                          {booking.status === 'confirmed' && (
                             <Button
                               variant="outline"
                               size="sm"
@@ -265,7 +315,7 @@ export function MyBookings({ user }: MyBookingsProps) {
                               Reagendar
                             </Button>
                           )}
-                          {booking.status === "pending" && (
+                          {booking.status === 'pending' && (
                             <Button variant="destructive" size="sm">
                               Cancelar
                             </Button>
@@ -276,7 +326,7 @@ export function MyBookings({ user }: MyBookingsProps) {
                   </div>
                 </CardContent>
               </Card>
-            )
+            );
           })}
         </div>
 
@@ -284,21 +334,28 @@ export function MyBookings({ user }: MyBookingsProps) {
           <Card className="border-2 border-dashed border-gray-200">
             <CardContent className="p-12 text-center">
               <Calendar className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-              <h3 className="text-xl font-medium text-gray-900 mb-2">No tienes citas programadas</h3>
-              <p className="text-gray-600 mb-6">Agenda tu primera cita médica para comenzar</p>
+              <h3 className="text-xl font-medium text-gray-900 mb-2">
+                No tienes reservas programadas
+              </h3>
+              <p className="text-gray-600 mb-6">
+                Reserva tu primer servicio para comenzar
+              </p>
               <Button
                 onClick={() => setShowNewBooking(true)}
                 className="bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700"
               >
                 <Plus className="w-4 h-4 mr-2" />
-                Agendar Cita
+                Reservar Servicio
               </Button>
             </CardContent>
           </Card>
         )}
       </div>
 
-      <NewBookingModal open={showNewBooking} onClose={() => setShowNewBooking(false)} />
+      <NewBookingModal
+        open={showNewBooking}
+        onClose={() => setShowNewBooking(false)}
+      />
     </div>
-  )
+  );
 }

--- a/components/company/bookings/company-booking-modal.tsx
+++ b/components/company/bookings/company-booking-modal.tsx
@@ -1,25 +1,40 @@
-"use client"
+'use client';
 
-import { useState } from "react"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Clock, ChevronLeft, ChevronRight, User } from "lucide-react"
-import type { Client } from "@/types/professional"
-import type { CompanyProfessional, Company, CompanyBooking } from "@/types/company"
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Clock, ChevronLeft, ChevronRight, User } from 'lucide-react';
+import type { Client } from '@/types/professional';
+import type {
+  CompanyProfessional,
+  Company,
+  CompanyBooking,
+} from '@/types/company';
 
 interface CompanyBookingModalProps {
-  open: boolean
-  onClose: () => void
-  clients: Client[]
-  professionals: CompanyProfessional[]
-  company: Company
-  onAddBooking: (booking: Omit<CompanyBooking, "id">) => void
-  onAddClient: (client: Omit<Client, "id" | "createdAt">) => Client
+  open: boolean;
+  onClose: () => void;
+  clients: Client[];
+  professionals: CompanyProfessional[];
+  company: Company;
+  onAddBooking: (booking: Omit<CompanyBooking, 'id'>) => void;
+  onAddClient: (client: Omit<Client, 'id' | 'createdAt'>) => Client;
 }
 
 export function CompanyBookingModal({
@@ -31,160 +46,180 @@ export function CompanyBookingModal({
   onAddBooking,
   onAddClient,
 }: CompanyBookingModalProps) {
-  const [step, setStep] = useState<"client" | "professional" | "service" | "datetime" | "confirmation">("client")
-  const [clientMode, setClientMode] = useState<"existing" | "new">("existing")
-  const [selectedClient, setSelectedClient] = useState<Client | null>(null)
-  const [newClientData, setNewClientData] = useState({ name: "", email: "", phone: "" })
-  const [selectedProfessional, setSelectedProfessional] = useState<CompanyProfessional | null>(null)
-  const [selectedService, setSelectedService] = useState<any>(null)
-  const [selectedDate, setSelectedDate] = useState<string>("")
-  const [selectedTime, setSelectedTime] = useState<string>("")
+  const [step, setStep] = useState<
+    'client' | 'professional' | 'service' | 'datetime' | 'confirmation'
+  >('client');
+  const [clientMode, setClientMode] = useState<'existing' | 'new'>('existing');
+  const [selectedClient, setSelectedClient] = useState<Client | null>(null);
+  const [newClientData, setNewClientData] = useState({
+    name: '',
+    email: '',
+    phone: '',
+  });
+  const [selectedProfessional, setSelectedProfessional] =
+    useState<CompanyProfessional | null>(null);
+  const [selectedService, setSelectedService] = useState<any>(null);
+  const [selectedDate, setSelectedDate] = useState<string>('');
+  const [selectedTime, setSelectedTime] = useState<string>('');
 
   // Mock services - in real app, these would come from the selected professional
   const services = [
     {
       id: 1,
-      name: "Consulta Médica General",
-      description: "Consulta médica general para diagnóstico y tratamiento",
+      name: 'Consulta Médica General',
+      description: 'Consulta médica general para diagnóstico y tratamiento',
       duration: 30,
       price: 150,
-      category: "Consulta",
+      category: 'Consulta',
     },
     {
       id: 2,
-      name: "Consulta Nutricional",
-      description: "Evaluación nutricional y plan alimentario personalizado",
+      name: 'Consulta Nutricional',
+      description: 'Evaluación nutricional y plan alimentario personalizado',
       duration: 45,
       price: 120,
-      category: "Consulta",
+      category: 'Consulta',
     },
-  ]
+  ];
 
   const dates = [
-    { day: "26", weekday: "JUE", month: "JUNIO" },
-    { day: "27", weekday: "VIE", month: "JUNIO" },
-    { day: "30", weekday: "LUN", month: "JUNIO" },
-    { day: "1", weekday: "MAR", month: "JULIO" },
-    { day: "2", weekday: "MIE", month: "JULIO" },
-    { day: "3", weekday: "JUE", month: "JULIO" },
-    { day: "4", weekday: "VIE", month: "JULIO" },
-  ]
+    { day: '26', weekday: 'JUE', month: 'JUNIO' },
+    { day: '27', weekday: 'VIE', month: 'JUNIO' },
+    { day: '30', weekday: 'LUN', month: 'JUNIO' },
+    { day: '1', weekday: 'MAR', month: 'JULIO' },
+    { day: '2', weekday: 'MIE', month: 'JULIO' },
+    { day: '3', weekday: 'JUE', month: 'JULIO' },
+    { day: '4', weekday: 'VIE', month: 'JULIO' },
+  ];
 
   const timeSlots = [
-    "09:00",
-    "09:30",
-    "10:00",
-    "10:30",
-    "11:00",
-    "11:30",
-    "12:00",
-    "12:30",
-    "13:00",
-    "13:30",
-    "14:00",
-    "14:30",
-    "15:00",
-    "15:30",
-    "16:00",
-    "16:30",
-  ]
+    '09:00',
+    '09:30',
+    '10:00',
+    '10:30',
+    '11:00',
+    '11:30',
+    '12:00',
+    '12:30',
+    '13:00',
+    '13:30',
+    '14:00',
+    '14:30',
+    '15:00',
+    '15:30',
+    '16:00',
+    '16:30',
+  ];
 
   const handleClientSelection = () => {
-    if (clientMode === "existing" && selectedClient) {
-      setStep("professional")
-    } else if (clientMode === "new" && newClientData.name && newClientData.email && newClientData.phone) {
-      const client = onAddClient(newClientData)
-      setSelectedClient(client)
-      setStep("professional")
+    if (clientMode === 'existing' && selectedClient) {
+      setStep('professional');
+    } else if (
+      clientMode === 'new' &&
+      newClientData.name &&
+      newClientData.email &&
+      newClientData.phone
+    ) {
+      const client = onAddClient(newClientData);
+      setSelectedClient(client);
+      setStep('professional');
     }
-  }
+  };
 
   const handleProfessionalSelect = (professional: CompanyProfessional) => {
-    setSelectedProfessional(professional)
-    setStep("service")
-  }
+    setSelectedProfessional(professional);
+    setStep('service');
+  };
 
   const handleServiceSelect = (service: any) => {
-    setSelectedService(service)
-    setStep("datetime")
-  }
+    setSelectedService(service);
+    setStep('datetime');
+  };
 
   const handleDateTimeSelect = () => {
     if (selectedDate && selectedTime) {
-      setStep("confirmation")
+      setStep('confirmation');
     }
-  }
+  };
 
   const handleConfirmBooking = () => {
-    if (selectedClient && selectedProfessional && selectedService && selectedDate && selectedTime) {
-      const booking: Omit<CompanyBooking, "id"> = {
+    if (
+      selectedClient &&
+      selectedProfessional &&
+      selectedService &&
+      selectedDate &&
+      selectedTime
+    ) {
+      const booking: Omit<CompanyBooking, 'id'> = {
         clientId: selectedClient.id,
         clientName: selectedClient.name,
         clientEmail: selectedClient.email,
         clientPhone: selectedClient.phone,
         serviceId: selectedService.id.toString(),
         serviceName: selectedService.name,
-        date: "2025-07-01", // Mock date
+        date: '2025-07-01', // Mock date
         time: selectedTime,
         duration: selectedService.duration,
         price: selectedService.price,
-        status: "pending",
+        status: 'pending',
         workplaceId: company.id,
         workplaceName: company.name,
         professionalId: selectedProfessional.id,
         professionalName: selectedProfessional.name,
-      }
+      };
 
-      onAddBooking(booking)
-      onClose()
-      resetModal()
+      onAddBooking(booking);
+      onClose();
+      resetModal();
     }
-  }
+  };
 
   const resetModal = () => {
-    setStep("client")
-    setClientMode("existing")
-    setSelectedClient(null)
-    setNewClientData({ name: "", email: "", phone: "" })
-    setSelectedProfessional(null)
-    setSelectedService(null)
-    setSelectedDate("")
-    setSelectedTime("")
-  }
+    setStep('client');
+    setClientMode('existing');
+    setSelectedClient(null);
+    setNewClientData({ name: '', email: '', phone: '' });
+    setSelectedProfessional(null);
+    setSelectedService(null);
+    setSelectedDate('');
+    setSelectedTime('');
+  };
 
   const renderClientSelection = () => (
     <div className="space-y-4">
       <div>
         <h3 className="text-lg font-semibold">Seleccionar Cliente</h3>
-        <p className="text-gray-600">Selecciona un cliente existente o registra uno nuevo</p>
+        <p className="text-gray-600">
+          Selecciona un cliente existente o registra uno nuevo
+        </p>
       </div>
 
       <div className="flex gap-2">
         <Button
-          variant={clientMode === "existing" ? "default" : "outline"}
-          onClick={() => setClientMode("existing")}
+          variant={clientMode === 'existing' ? 'default' : 'outline'}
+          onClick={() => setClientMode('existing')}
           className="flex-1"
         >
           Cliente Existente
         </Button>
         <Button
-          variant={clientMode === "new" ? "default" : "outline"}
-          onClick={() => setClientMode("new")}
+          variant={clientMode === 'new' ? 'default' : 'outline'}
+          onClick={() => setClientMode('new')}
           className="flex-1"
         >
           Nuevo Cliente
         </Button>
       </div>
 
-      {clientMode === "existing" ? (
+      {clientMode === 'existing' ? (
         <div className="space-y-4">
           <div>
             <Label>Seleccionar Cliente</Label>
             <Select
               value={selectedClient?.id}
               onValueChange={(value) => {
-                const client = clients.find((c) => c.id === value)
-                setSelectedClient(client || null)
+                const client = clients.find((c) => c.id === value);
+                setSelectedClient(client || null);
               }}
             >
               <SelectTrigger className="mt-1">
@@ -213,7 +248,9 @@ export function CompanyBookingModal({
             <Input
               id="clientName"
               value={newClientData.name}
-              onChange={(e) => setNewClientData((prev) => ({ ...prev, name: e.target.value }))}
+              onChange={(e) =>
+                setNewClientData((prev) => ({ ...prev, name: e.target.value }))
+              }
               placeholder="Nombre del cliente"
               className="mt-1"
             />
@@ -224,7 +261,9 @@ export function CompanyBookingModal({
               id="clientEmail"
               type="email"
               value={newClientData.email}
-              onChange={(e) => setNewClientData((prev) => ({ ...prev, email: e.target.value }))}
+              onChange={(e) =>
+                setNewClientData((prev) => ({ ...prev, email: e.target.value }))
+              }
               placeholder="email@ejemplo.com"
               className="mt-1"
             />
@@ -234,7 +273,9 @@ export function CompanyBookingModal({
             <Input
               id="clientPhone"
               value={newClientData.phone}
-              onChange={(e) => setNewClientData((prev) => ({ ...prev, phone: e.target.value }))}
+              onChange={(e) =>
+                setNewClientData((prev) => ({ ...prev, phone: e.target.value }))
+              }
               placeholder="+1234567890"
               className="mt-1"
             />
@@ -249,26 +290,30 @@ export function CompanyBookingModal({
         <Button
           onClick={handleClientSelection}
           disabled={
-            clientMode === "existing"
+            clientMode === 'existing'
               ? !selectedClient
-              : !newClientData.name || !newClientData.email || !newClientData.phone
+              : !newClientData.name ||
+                !newClientData.email ||
+                !newClientData.phone
           }
         >
           Continuar
         </Button>
       </div>
     </div>
-  )
+  );
 
   const renderProfessionalSelection = () => (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
-        <Button variant="ghost" size="sm" onClick={() => setStep("client")}>
+        <Button variant="ghost" size="sm" onClick={() => setStep('client')}>
           <ChevronLeft className="w-4 h-4" />
         </Button>
         <div>
           <h3 className="text-lg font-semibold">Seleccionar Profesional</h3>
-          <p className="text-gray-600">Elige el profesional para {selectedClient?.name}</p>
+          <p className="text-gray-600">
+            Elige el profesional para {selectedClient?.name}
+          </p>
         </div>
       </div>
 
@@ -288,18 +333,24 @@ export function CompanyBookingModal({
                       <h4 className="font-semibold">{professional.name}</h4>
                       <p className="text-gray-600">{professional.title}</p>
                     </div>
-                    <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Activo</Badge>
+                    <Badge className="bg-green-100 text-green-800 hover:bg-green-100">
+                      Activo
+                    </Badge>
                   </div>
                   <div className="flex flex-wrap gap-1">
                     {professional.specialties.map((specialty) => (
-                      <Badge key={specialty} variant="outline" className="text-xs">
+                      <Badge
+                        key={specialty}
+                        variant="outline"
+                        className="text-xs"
+                      >
                         {specialty}
                       </Badge>
                     ))}
                   </div>
                   <div className="flex justify-between text-sm text-gray-500">
                     <span>Rating: {professional.rating}</span>
-                    <span>Hoy: {professional.todayBookings} citas</span>
+                    <span>Hoy: {professional.todayBookings} reservas</span>
                   </div>
                 </div>
               </CardContent>
@@ -307,17 +358,23 @@ export function CompanyBookingModal({
           ))}
       </div>
     </div>
-  )
+  );
 
   const renderServiceSelection = () => (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
-        <Button variant="ghost" size="sm" onClick={() => setStep("professional")}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setStep('professional')}
+        >
           <ChevronLeft className="w-4 h-4" />
         </Button>
         <div>
           <h3 className="text-lg font-semibold">Seleccionar Servicio</h3>
-          <p className="text-gray-600">Servicios disponibles con {selectedProfessional?.name}</p>
+          <p className="text-gray-600">
+            Servicios disponibles con {selectedProfessional?.name}
+          </p>
         </div>
       </div>
 
@@ -342,7 +399,9 @@ export function CompanyBookingModal({
                     <Clock className="w-4 h-4" />
                     {service.duration} min
                   </div>
-                  <div className="text-lg font-semibold text-green-600">${service.price}</div>
+                  <div className="text-lg font-semibold text-green-600">
+                    ${service.price}
+                  </div>
                 </div>
               </div>
             </CardContent>
@@ -350,12 +409,12 @@ export function CompanyBookingModal({
         ))}
       </div>
     </div>
-  )
+  );
 
   const renderDateTimeSelection = () => (
     <div className="space-y-6">
       <div className="flex items-center gap-2">
-        <Button variant="ghost" size="sm" onClick={() => setStep("service")}>
+        <Button variant="ghost" size="sm" onClick={() => setStep('service')}>
           <ChevronLeft className="w-4 h-4" />
         </Button>
         <div>
@@ -385,8 +444,8 @@ export function CompanyBookingModal({
             onClick={() => setSelectedDate(`${date.day}/${date.month}`)}
             className={`p-3 text-center rounded-lg border transition-colors ${
               selectedDate === `${date.day}/${date.month}`
-                ? "bg-blue-600 text-white border-blue-600"
-                : "bg-white border-gray-200 hover:border-gray-300"
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white border-gray-200 hover:border-gray-300'
             }`}
           >
             <div className="text-lg font-semibold">{date.day}</div>
@@ -400,7 +459,9 @@ export function CompanyBookingModal({
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <h4 className="font-semibold">Selecciona una hora</h4>
-            <p className="text-sm text-gray-600">16 disponibles de 16 horarios</p>
+            <p className="text-sm text-gray-600">
+              16 disponibles de 16 horarios
+            </p>
           </div>
           <div className="grid grid-cols-4 gap-2">
             {timeSlots.map((time) => (
@@ -409,8 +470,8 @@ export function CompanyBookingModal({
                 onClick={() => setSelectedTime(time)}
                 className={`p-2 text-center rounded-lg border transition-colors ${
                   selectedTime === time
-                    ? "bg-blue-600 text-white border-blue-600"
-                    : "bg-white border-gray-200 hover:border-gray-300"
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white border-gray-200 hover:border-gray-300'
                 }`}
               >
                 {time}
@@ -421,7 +482,7 @@ export function CompanyBookingModal({
       )}
 
       <div className="flex gap-2">
-        <Button variant="outline" onClick={() => setStep("service")}>
+        <Button variant="outline" onClick={() => setStep('service')}>
           Volver
         </Button>
         <Button
@@ -433,13 +494,15 @@ export function CompanyBookingModal({
         </Button>
       </div>
     </div>
-  )
+  );
 
   const renderConfirmation = () => (
     <div className="space-y-6">
       <div>
         <h3 className="text-lg font-semibold">Confirmar Reserva</h3>
-        <p className="text-gray-600">Revisa y confirma los detalles de la reserva</p>
+        <p className="text-gray-600">
+          Revisa y confirma los detalles de la reserva
+        </p>
       </div>
 
       <div className="space-y-4">
@@ -480,24 +543,29 @@ export function CompanyBookingModal({
           </div>
           <div className="flex justify-between">
             <span className="text-gray-600">Precio:</span>
-            <span className="font-semibold text-green-600">${selectedService?.price}</span>
+            <span className="font-semibold text-green-600">
+              ${selectedService?.price}
+            </span>
           </div>
         </div>
       </div>
 
       <div className="flex gap-2">
-        <Button variant="outline" onClick={() => setStep("datetime")}>
+        <Button variant="outline" onClick={() => setStep('datetime')}>
           Volver
         </Button>
         <Button variant="outline" onClick={onClose}>
           Cancelar
         </Button>
-        <Button onClick={handleConfirmBooking} className="bg-gray-600 hover:bg-gray-700">
+        <Button
+          onClick={handleConfirmBooking}
+          className="bg-gray-600 hover:bg-gray-700"
+        >
           Crear Reserva
         </Button>
       </div>
     </div>
-  )
+  );
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
@@ -508,13 +576,13 @@ export function CompanyBookingModal({
         </DialogHeader>
 
         <div className="mt-6">
-          {step === "client" && renderClientSelection()}
-          {step === "professional" && renderProfessionalSelection()}
-          {step === "service" && renderServiceSelection()}
-          {step === "datetime" && renderDateTimeSelection()}
-          {step === "confirmation" && renderConfirmation()}
+          {step === 'client' && renderClientSelection()}
+          {step === 'professional' && renderProfessionalSelection()}
+          {step === 'service' && renderServiceSelection()}
+          {step === 'datetime' && renderDateTimeSelection()}
+          {step === 'confirmation' && renderConfirmation()}
         </div>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/components/professional/calendar/calendar-view.tsx
+++ b/components/professional/calendar/calendar-view.tsx
@@ -1,262 +1,281 @@
-"use client"
+'use client';
 
-import type React from "react"
+import type React from 'react';
 
-import { useState, useCallback } from "react"
-import { Card, CardContent } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { ChevronLeft, ChevronRight, MapPin, Clock, User } from "lucide-react"
-import type { Booking, Workplace } from "@/types/professional"
+import { useState, useCallback } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronRight, MapPin, Clock, User } from 'lucide-react';
+import type { Booking, Workplace } from '@/types/professional';
 
 interface CalendarViewProps {
-  bookings: Booking[]
-  selectedWorkplace?: Workplace
+  bookings: Booking[];
+  selectedWorkplace?: Workplace;
 }
 
 interface CalendarEvent {
-  id: string
-  title: string
-  startTime: string
-  endTime: string
-  day: number
-  date: string
-  workplace: string
-  color: string
-  client?: string
-  service?: string
-  bookingId?: string
+  id: string;
+  title: string;
+  startTime: string;
+  endTime: string;
+  day: number;
+  date: string;
+  workplace: string;
+  color: string;
+  client?: string;
+  service?: string;
+  bookingId?: string;
 }
 
-export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps) {
+export function CalendarView({
+  bookings,
+  selectedWorkplace,
+}: CalendarViewProps) {
   const [currentWeekStart, setCurrentWeekStart] = useState(() => {
-    const today = new Date()
-    const dayOfWeek = today.getDay()
-    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek
-    const monday = new Date(today)
-    monday.setDate(today.getDate() + mondayOffset)
-    monday.setHours(0, 0, 0, 0)
-    return monday
-  })
+    const today = new Date();
+    const dayOfWeek = today.getDay();
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    const monday = new Date(today);
+    monday.setDate(today.getDate() + mondayOffset);
+    monday.setHours(0, 0, 0, 0);
+    return monday;
+  });
 
-  const [draggedEvent, setDraggedEvent] = useState<CalendarEvent | null>(null)
-  const [dragOverSlot, setDragOverSlot] = useState<{ day: number; hour: number } | null>(null)
+  const [draggedEvent, setDraggedEvent] = useState<CalendarEvent | null>(null);
+  const [dragOverSlot, setDragOverSlot] = useState<{
+    day: number;
+    hour: number;
+  } | null>(null);
 
-  const weekDays = ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"]
-  const hours = Array.from({ length: 13 }, (_, i) => i + 8) // 8 AM to 8 PM
+  const weekDays = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
+  const hours = Array.from({ length: 13 }, (_, i) => i + 8); // 8 AM to 8 PM
 
   // Colores para diferentes lugares de trabajo
   const workplaceColors = {
-    "Clínica San Juan": "bg-blue-500",
-    "Hospital Central": "bg-green-500",
-    "Consultorio Privado": "bg-purple-500",
-    "Centro Médico Norte": "bg-orange-500",
-    Almuerzo: "bg-red-500",
-  }
+    'Clínica San Juan': 'bg-blue-500',
+    'Hospital Central': 'bg-green-500',
+    'Consultorio Privado': 'bg-purple-500',
+    'Centro Médico Norte': 'bg-orange-500',
+    Almuerzo: 'bg-red-500',
+  };
 
   // Calcular fechas de la semana actual
   const getWeekDates = useCallback(() => {
-    const dates = []
+    const dates = [];
     for (let i = 0; i < 7; i++) {
-      const date = new Date(currentWeekStart)
-      date.setDate(currentWeekStart.getDate() + i)
+      const date = new Date(currentWeekStart);
+      date.setDate(currentWeekStart.getDate() + i);
       dates.push({
         day: i + 1,
         date: date.getDate(),
-        fullDate: date.toISOString().split("T")[0],
-        displayDate: date.toLocaleDateString("es-ES", { day: "2-digit", month: "short" }),
-      })
+        fullDate: date.toISOString().split('T')[0],
+        displayDate: date.toLocaleDateString('es-ES', {
+          day: '2-digit',
+          month: 'short',
+        }),
+      });
     }
-    return dates
-  }, [currentWeekStart])
+    return dates;
+  }, [currentWeekStart]);
 
-  const weekDates = getWeekDates()
+  const weekDates = getWeekDates();
 
   // Navegación semanal
-  const navigateWeek = (direction: "prev" | "next") => {
-    const newWeekStart = new Date(currentWeekStart)
-    newWeekStart.setDate(currentWeekStart.getDate() + (direction === "next" ? 7 : -7))
-    setCurrentWeekStart(newWeekStart)
-  }
+  const navigateWeek = (direction: 'prev' | 'next') => {
+    const newWeekStart = new Date(currentWeekStart);
+    newWeekStart.setDate(
+      currentWeekStart.getDate() + (direction === 'next' ? 7 : -7)
+    );
+    setCurrentWeekStart(newWeekStart);
+  };
 
   const goToToday = () => {
-    const today = new Date()
-    const dayOfWeek = today.getDay()
-    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek
-    const monday = new Date(today)
-    monday.setDate(today.getDate() + mondayOffset)
-    monday.setHours(0, 0, 0, 0)
-    setCurrentWeekStart(monday)
-  }
+    const today = new Date();
+    const dayOfWeek = today.getDay();
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    const monday = new Date(today);
+    monday.setDate(today.getDate() + mondayOffset);
+    monday.setHours(0, 0, 0, 0);
+    setCurrentWeekStart(monday);
+  };
 
   // Eventos de ejemplo con fechas reales
   const events: CalendarEvent[] = [
     {
-      id: "1",
-      title: "Consulta General",
-      startTime: "10:00",
-      endTime: "10:30",
+      id: '1',
+      title: 'Consulta General',
+      startTime: '10:00',
+      endTime: '10:30',
       day: 1,
       date: weekDates[0].fullDate,
-      workplace: "Clínica San Juan",
-      color: workplaceColors["Clínica San Juan"],
-      client: "María García",
-      service: "Consulta General",
-      bookingId: "booking-1",
+      workplace: 'Clínica San Juan',
+      color: workplaceColors['Clínica San Juan'],
+      client: 'María García',
+      service: 'Consulta General',
+      bookingId: 'booking-1',
     },
     {
-      id: "2",
-      title: "Consulta Especializada",
-      startTime: "10:00",
-      endTime: "11:00",
+      id: '2',
+      title: 'Consulta Especializada',
+      startTime: '10:00',
+      endTime: '11:00',
       day: 2,
       date: weekDates[1].fullDate,
-      workplace: "Hospital Central",
-      color: workplaceColors["Hospital Central"],
-      client: "Carlos López",
-      service: "Consulta Especializada",
-      bookingId: "booking-2",
+      workplace: 'Hospital Central',
+      color: workplaceColors['Hospital Central'],
+      client: 'Carlos López',
+      service: 'Consulta Especializada',
+      bookingId: 'booking-2',
     },
     {
-      id: "3",
-      title: "Reunión Médica",
-      startTime: "10:30",
-      endTime: "12:00",
+      id: '3',
+      title: 'Reunión Médica',
+      startTime: '10:30',
+      endTime: '12:00',
       day: 3,
       date: weekDates[2].fullDate,
-      workplace: "Centro Médico Norte",
-      color: workplaceColors["Centro Médico Norte"],
-      service: "Reunión de Equipo",
-      bookingId: "booking-3",
+      workplace: 'Centro Médico Norte',
+      color: workplaceColors['Centro Médico Norte'],
+      service: 'Reunión de Equipo',
+      bookingId: 'booking-3',
     },
     // Almuerzos para toda la semana
     ...weekDates.slice(0, 5).map((date, index) => ({
       id: `lunch-${index + 1}`,
-      title: "Almuerzo",
-      startTime: "13:00",
-      endTime: "14:00",
+      title: 'Almuerzo',
+      startTime: '13:00',
+      endTime: '14:00',
       day: index + 1,
       date: date.fullDate,
-      workplace: "Almuerzo",
-      color: workplaceColors["Almuerzo"],
+      workplace: 'Almuerzo',
+      color: workplaceColors['Almuerzo'],
     })),
     {
-      id: "7",
-      title: "Consulta de Control",
-      startTime: "15:00",
-      endTime: "15:30",
+      id: '7',
+      title: 'Consulta de Control',
+      startTime: '15:00',
+      endTime: '15:30',
       day: 4,
       date: weekDates[3].fullDate,
-      workplace: "Consultorio Privado",
-      color: workplaceColors["Consultorio Privado"],
-      client: "Ana Martínez",
-      service: "Control",
-      bookingId: "booking-4",
+      workplace: 'Consultorio Privado',
+      color: workplaceColors['Consultorio Privado'],
+      client: 'Ana Martínez',
+      service: 'Control',
+      bookingId: 'booking-4',
     },
     {
-      id: "8",
-      title: "Consulta Urgente",
-      startTime: "16:00",
-      endTime: "16:30",
+      id: '8',
+      title: 'Consulta Urgente',
+      startTime: '16:00',
+      endTime: '16:30',
       day: 5,
       date: weekDates[4].fullDate,
-      workplace: "Clínica San Juan",
-      color: workplaceColors["Clínica San Juan"],
-      client: "Pedro Rodríguez",
-      service: "Urgencia",
-      bookingId: "booking-5",
+      workplace: 'Clínica San Juan',
+      color: workplaceColors['Clínica San Juan'],
+      client: 'Pedro Rodríguez',
+      service: 'Urgencia',
+      bookingId: 'booking-5',
     },
-  ]
+  ];
 
   const getTimePosition = (time: string) => {
-    const [hours, minutes] = time.split(":").map(Number)
-    const totalMinutes = (hours - 8) * 60 + minutes
-    return (totalMinutes / 60) * 60 // 60px per hour
-  }
+    const [hours, minutes] = time.split(':').map(Number);
+    const totalMinutes = (hours - 8) * 60 + minutes;
+    return (totalMinutes / 60) * 60; // 60px per hour
+  };
 
   const getEventHeight = (startTime: string, endTime: string) => {
-    const start = getTimePosition(startTime)
-    const end = getTimePosition(endTime)
-    return Math.max(end - start, 30) // Minimum 30px height
-  }
+    const start = getTimePosition(startTime);
+    const end = getTimePosition(endTime);
+    return Math.max(end - start, 30); // Minimum 30px height
+  };
 
   const getTimeFromPosition = (position: number) => {
-    const totalMinutes = (position / 60) * 60
-    const hours = Math.floor(totalMinutes / 60) + 8
-    const minutes = Math.round((totalMinutes % 60) / 15) * 15 // Snap to 15-minute intervals
-    return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`
-  }
+    const totalMinutes = (position / 60) * 60;
+    const hours = Math.floor(totalMinutes / 60) + 8;
+    const minutes = Math.round((totalMinutes % 60) / 15) * 15; // Snap to 15-minute intervals
+    return `${hours.toString().padStart(2, '0')}:${minutes
+      .toString()
+      .padStart(2, '0')}`;
+  };
 
   // Drag and Drop handlers
   const handleDragStart = (e: React.DragEvent, event: CalendarEvent) => {
-    setDraggedEvent(event)
-    e.dataTransfer.effectAllowed = "move"
-    e.dataTransfer.setData("text/html", e.currentTarget.outerHTML)
+    setDraggedEvent(event);
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/html', e.currentTarget.outerHTML);
 
     // Add visual feedback
-    const dragImage = e.currentTarget.cloneNode(true) as HTMLElement
-    dragImage.style.opacity = "0.8"
-    dragImage.style.transform = "rotate(5deg)"
-    e.dataTransfer.setDragImage(dragImage, 0, 0)
-  }
+    const dragImage = e.currentTarget.cloneNode(true) as HTMLElement;
+    dragImage.style.opacity = '0.8';
+    dragImage.style.transform = 'rotate(5deg)';
+    e.dataTransfer.setDragImage(dragImage, 0, 0);
+  };
 
   const handleDragOver = (e: React.DragEvent, day: number, hour: number) => {
-    e.preventDefault()
-    e.dataTransfer.dropEffect = "move"
-    setDragOverSlot({ day, hour })
-  }
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverSlot({ day, hour });
+  };
 
   const handleDragLeave = () => {
-    setDragOverSlot(null)
-  }
+    setDragOverSlot(null);
+  };
 
   const handleDrop = (e: React.DragEvent, day: number, hour: number) => {
-    e.preventDefault()
+    e.preventDefault();
 
-    if (!draggedEvent) return
+    if (!draggedEvent) return;
 
-    const rect = e.currentTarget.getBoundingClientRect()
-    const y = e.clientY - rect.top
-    const newStartTime = getTimeFromPosition(y)
+    const rect = e.currentTarget.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    const newStartTime = getTimeFromPosition(y);
 
     // Calculate new end time based on original duration
-    const originalStart = draggedEvent.startTime.split(":").map(Number)
-    const originalEnd = draggedEvent.endTime.split(":").map(Number)
-    const durationMinutes = originalEnd[0] * 60 + originalEnd[1] - (originalStart[0] * 60 + originalStart[1])
+    const originalStart = draggedEvent.startTime.split(':').map(Number);
+    const originalEnd = draggedEvent.endTime.split(':').map(Number);
+    const durationMinutes =
+      originalEnd[0] * 60 +
+      originalEnd[1] -
+      (originalStart[0] * 60 + originalStart[1]);
 
     const newStartMinutes =
-      Number.parseInt(newStartTime.split(":")[0]) * 60 + Number.parseInt(newStartTime.split(":")[1])
-    const newEndMinutes = newStartMinutes + durationMinutes
+      Number.parseInt(newStartTime.split(':')[0]) * 60 +
+      Number.parseInt(newStartTime.split(':')[1]);
+    const newEndMinutes = newStartMinutes + durationMinutes;
     const newEndTime = `${Math.floor(newEndMinutes / 60)
       .toString()
-      .padStart(2, "0")}:${(newEndMinutes % 60).toString().padStart(2, "0")}`
+      .padStart(2, '0')}:${(newEndMinutes % 60).toString().padStart(2, '0')}`;
 
-    console.log(`Moved event "${draggedEvent.title}" to day ${day} at ${newStartTime}-${newEndTime}`)
+    console.log(
+      `Moved event "${draggedEvent.title}" to day ${day} at ${newStartTime}-${newEndTime}`
+    );
 
     // Here you would update the event in your state/database
     // For now, we'll just log the change
 
-    setDraggedEvent(null)
-    setDragOverSlot(null)
-  }
+    setDraggedEvent(null);
+    setDragOverSlot(null);
+  };
 
   const formatWeekRange = () => {
-    const endDate = new Date(currentWeekStart)
-    endDate.setDate(currentWeekStart.getDate() + 6)
+    const endDate = new Date(currentWeekStart);
+    endDate.setDate(currentWeekStart.getDate() + 6);
 
-    const startStr = currentWeekStart.toLocaleDateString("es-ES", {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    })
+    const startStr = currentWeekStart.toLocaleDateString('es-ES', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
 
-    const endStr = endDate.toLocaleDateString("es-ES", {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    })
+    const endStr = endDate.toLocaleDateString('es-ES', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
 
-    return `${startStr} - ${endStr}`
-  }
+    return `${startStr} - ${endStr}`;
+  };
 
   return (
     <div className="space-y-6">
@@ -269,10 +288,18 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
           <Button variant="outline" size="sm" onClick={goToToday}>
             Hoy
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => navigateWeek("prev")}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigateWeek('prev')}
+          >
             <ChevronLeft className="w-4 h-4" />
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => navigateWeek("next")}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigateWeek('next')}
+          >
             <ChevronRight className="w-4 h-4" />
           </Button>
         </div>
@@ -280,7 +307,9 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
 
       {/* Leyenda de colores */}
       <div className="flex flex-wrap gap-4 p-4 bg-gray-50 rounded-lg">
-        <div className="text-sm font-medium text-gray-700">Lugares de trabajo:</div>
+        <div className="text-sm font-medium text-gray-700">
+          Lugares de trabajo:
+        </div>
         {Object.entries(workplaceColors).map(([workplace, color]) => (
           <div key={workplace} className="flex items-center gap-2">
             <div className={`w-3 h-3 rounded ${color}`}></div>
@@ -289,7 +318,7 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
         ))}
         <div className="ml-auto text-xs text-gray-500 flex items-center gap-1">
           <Clock className="w-3 h-3" />
-          Arrastra las citas para reprogramar
+          Arrastra las reservas para reprogramar
         </div>
       </div>
 
@@ -299,19 +328,36 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
           <div className="grid grid-cols-8 border-b">
             <div className="p-4 border-r bg-gray-50"></div>
             {weekDays.map((day, index) => {
-              const dateInfo = weekDates[index]
-              const isToday = dateInfo.fullDate === new Date().toISOString().split("T")[0]
+              const dateInfo = weekDates[index];
+              const isToday =
+                dateInfo.fullDate === new Date().toISOString().split('T')[0];
 
               return (
                 <div
                   key={day}
-                  className={`p-4 text-center border-r last:border-r-0 ${isToday ? "bg-blue-50" : "bg-gray-50"}`}
+                  className={`p-4 text-center border-r last:border-r-0 ${
+                    isToday ? 'bg-blue-50' : 'bg-gray-50'
+                  }`}
                 >
-                  <div className={`font-medium ${isToday ? "text-blue-600" : "text-gray-900"}`}>{day}</div>
-                  <div className={`text-sm ${isToday ? "text-blue-500" : "text-gray-500"}`}>{dateInfo.displayDate}</div>
-                  {isToday && <div className="w-2 h-2 bg-blue-500 rounded-full mx-auto mt-1"></div>}
+                  <div
+                    className={`font-medium ${
+                      isToday ? 'text-blue-600' : 'text-gray-900'
+                    }`}
+                  >
+                    {day}
+                  </div>
+                  <div
+                    className={`text-sm ${
+                      isToday ? 'text-blue-500' : 'text-gray-500'
+                    }`}
+                  >
+                    {dateInfo.displayDate}
+                  </div>
+                  {isToday && (
+                    <div className="w-2 h-2 bg-blue-500 rounded-full mx-auto mt-1"></div>
+                  )}
                 </div>
-              )
+              );
             })}
           </div>
 
@@ -319,17 +365,24 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
           <div className="relative">
             {/* Líneas de horas */}
             {hours.map((hour) => (
-              <div key={hour} className="grid grid-cols-8 border-b" style={{ height: "60px" }}>
+              <div
+                key={hour}
+                className="grid grid-cols-8 border-b"
+                style={{ height: '60px' }}
+              >
                 <div className="p-2 border-r bg-gray-50 flex items-start justify-end">
-                  <span className="text-sm text-gray-600 font-medium">{hour}:00</span>
+                  <span className="text-sm text-gray-600 font-medium">
+                    {hour}:00
+                  </span>
                 </div>
                 {weekDays.map((_, dayIndex) => (
                   <div
                     key={dayIndex}
                     className={`border-r last:border-r-0 relative transition-colors ${
-                      dragOverSlot?.day === dayIndex + 1 && dragOverSlot?.hour === hour
-                        ? "bg-blue-100"
-                        : "hover:bg-gray-50"
+                      dragOverSlot?.day === dayIndex + 1 &&
+                      dragOverSlot?.hour === hour
+                        ? 'bg-blue-100'
+                        : 'hover:bg-gray-50'
                     }`}
                     onDragOver={(e) => handleDragOver(e, dayIndex + 1, hour)}
                     onDragLeave={handleDragLeave}
@@ -350,22 +403,28 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
             {events.map((event) => (
               <div
                 key={event.id}
-                draggable={event.workplace !== "Almuerzo"}
+                draggable={event.workplace !== 'Almuerzo'}
                 onDragStart={(e) => handleDragStart(e, event)}
-                className={`absolute ${event.color} text-white text-xs p-2 rounded shadow-sm transition-all duration-200 ${
-                  event.workplace !== "Almuerzo"
-                    ? "cursor-move hover:opacity-90 hover:shadow-md hover:scale-105"
-                    : "cursor-default"
-                } ${draggedEvent?.id === event.id ? "opacity-50" : ""}`}
+                className={`absolute ${
+                  event.color
+                } text-white text-xs p-2 rounded shadow-sm transition-all duration-200 ${
+                  event.workplace !== 'Almuerzo'
+                    ? 'cursor-move hover:opacity-90 hover:shadow-md hover:scale-105'
+                    : 'cursor-default'
+                } ${draggedEvent?.id === event.id ? 'opacity-50' : ''}`}
                 style={{
                   top: `${getTimePosition(event.startTime) + 41}px`, // +41px para el header
                   left: `${12.5 + (event.day - 1) * 12.5}%`,
-                  width: "12%",
+                  width: '12%',
                   height: `${getEventHeight(event.startTime, event.endTime)}px`,
-                  minHeight: "30px",
+                  minHeight: '30px',
                   zIndex: draggedEvent?.id === event.id ? 1000 : 10,
                 }}
-                title={`${event.title} - ${event.startTime} a ${event.endTime}${event.client ? ` - ${event.client}` : ""}${event.workplace !== "Almuerzo" ? " (Arrastra para mover)" : ""}`}
+                title={`${event.title} - ${event.startTime} a ${event.endTime}${
+                  event.client ? ` - ${event.client}` : ''
+                }${
+                  event.workplace !== 'Almuerzo' ? ' (Arrastra para mover)' : ''
+                }`}
               >
                 <div className="font-medium truncate">{event.title}</div>
                 {event.client && (
@@ -388,14 +447,21 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
                 style={{
                   top: `${dragOverSlot.hour * 60 - 8 * 60 + 41}px`,
                   left: `${12.5 + (dragOverSlot.day - 1) * 12.5}%`,
-                  width: "12%",
-                  height: `${getEventHeight(draggedEvent.startTime, draggedEvent.endTime)}px`,
-                  minHeight: "30px",
+                  width: '12%',
+                  height: `${getEventHeight(
+                    draggedEvent.startTime,
+                    draggedEvent.endTime
+                  )}px`,
+                  minHeight: '30px',
                   zIndex: 1001,
                 }}
               >
                 <div className="font-medium truncate">{draggedEvent.title}</div>
-                {draggedEvent.client && <div className="text-xs opacity-90 truncate">{draggedEvent.client}</div>}
+                {draggedEvent.client && (
+                  <div className="text-xs opacity-90 truncate">
+                    {draggedEvent.client}
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -410,7 +476,7 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
               <div className="w-3 h-3 rounded bg-blue-500"></div>
               <div>
                 <div className="text-sm text-gray-600">Clínica San Juan</div>
-                <div className="font-semibold">2 citas</div>
+                <div className="font-semibold">2 reservas</div>
               </div>
             </div>
           </CardContent>
@@ -421,7 +487,7 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
               <div className="w-3 h-3 rounded bg-green-500"></div>
               <div>
                 <div className="text-sm text-gray-600">Hospital Central</div>
-                <div className="font-semibold">1 cita</div>
+                <div className="font-semibold">1 reserva</div>
               </div>
             </div>
           </CardContent>
@@ -432,7 +498,7 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
               <div className="w-3 h-3 rounded bg-purple-500"></div>
               <div>
                 <div className="text-sm text-gray-600">Consultorio Privado</div>
-                <div className="font-semibold">1 cita</div>
+                <div className="font-semibold">1 reserva</div>
               </div>
             </div>
           </CardContent>
@@ -443,12 +509,12 @@ export function CalendarView({ bookings, selectedWorkplace }: CalendarViewProps)
               <MapPin className="w-4 h-4 text-gray-500" />
               <div>
                 <div className="text-sm text-gray-600">Total esta semana</div>
-                <div className="font-semibold">4 citas</div>
+                <div className="font-semibold">4 reservas</div>
               </div>
             </div>
           </CardContent>
         </Card>
       </div>
     </div>
-  )
+  );
 }

--- a/components/professional/dashboard/dashboard.tsx
+++ b/components/professional/dashboard/dashboard.tsx
@@ -1,52 +1,56 @@
-"use client"
+'use client';
 
-import { Card, CardContent } from "@/components/ui/card"
-import { Calendar, Clock, TrendingUp, DollarSign, User } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
-import type { DashboardStats, Booking, Workplace } from "@/types/professional"
+import { Card, CardContent } from '@/components/ui/card';
+import { Calendar, Clock, TrendingUp, DollarSign, User } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { DashboardStats, Booking, Workplace } from '@/types/professional';
 
 interface DashboardProps {
-  stats: DashboardStats
-  bookings: Booking[]
-  selectedWorkplace?: Workplace
+  stats: DashboardStats;
+  bookings: Booking[];
+  selectedWorkplace?: Workplace;
 }
 
-export function Dashboard({ stats, bookings, selectedWorkplace }: DashboardProps) {
+export function Dashboard({
+  stats,
+  bookings,
+  selectedWorkplace,
+}: DashboardProps) {
   const todayBookings = bookings.filter((b) => {
-    const today = new Date().toISOString().split("T")[0]
-    return b.date === today && b.workplaceId === selectedWorkplace?.id
-  })
+    const today = new Date().toISOString().split('T')[0];
+    return b.date === today && b.workplaceId === selectedWorkplace?.id;
+  });
 
   const statsCards = [
     {
-      title: "Citas Hoy",
-      value: stats.todayAppointments.toString(),
+      title: 'Reservas Hoy',
+      value: stats.todayBookings.toString(),
       subtitle: `En ${selectedWorkplace?.name}`,
       icon: Calendar,
-      color: "text-blue-600",
+      color: 'text-blue-600',
     },
     {
-      title: "Pendientes",
+      title: 'Pendientes',
       value: stats.pendingBookings.toString(),
-      subtitle: "Requieren confirmación",
+      subtitle: 'Requieren confirmación',
       icon: Clock,
-      color: "text-yellow-600",
+      color: 'text-yellow-600',
     },
     {
-      title: "Esta Semana",
-      value: stats.weeklyAppointments.toString(),
-      subtitle: "Citas programadas",
+      title: 'Esta Semana',
+      value: stats.weeklyBookings.toString(),
+      subtitle: 'Reservas programadas',
       icon: TrendingUp,
-      color: "text-purple-600",
+      color: 'text-purple-600',
     },
     {
-      title: "Ingresos del Mes",
+      title: 'Ingresos del Mes',
       value: `$${stats.monthlyRevenue.toLocaleString()}`,
-      subtitle: "En esta ubicación",
+      subtitle: 'En esta ubicación',
       icon: DollarSign,
-      color: "text-green-600",
+      color: 'text-green-600',
     },
-  ]
+  ];
 
   return (
     <div className="space-y-6">
@@ -68,43 +72,56 @@ export function Dashboard({ stats, bookings, selectedWorkplace }: DashboardProps
         ))}
       </div>
 
-      {/* Today's Appointments */}
+      {/* Today's Bookings */}
       <Card>
         <CardContent className="p-6">
           <div className="flex justify-between items-center mb-6">
             <div>
-              <h2 className="text-xl font-semibold">Próximas Citas - {selectedWorkplace?.name}</h2>
-              <p className="text-gray-600">Tus próximas citas en esta ubicación</p>
+              <h2 className="text-xl font-semibold">
+                Próximas Reservas - {selectedWorkplace?.name}
+              </h2>
+              <p className="text-gray-600">
+                Tus próximas reservas en esta ubicación
+              </p>
             </div>
           </div>
 
           <div className="space-y-4">
             {todayBookings.length === 0 ? (
-              <p className="text-gray-500 text-center py-8">No tienes citas programadas para hoy</p>
+              <p className="text-gray-500 text-center py-8">
+                No tienes reservas programadas para hoy
+              </p>
             ) : (
               todayBookings.map((booking) => (
-                <div key={booking.id} className="flex items-center gap-4 p-4 bg-gray-50 rounded-lg">
+                <div
+                  key={booking.id}
+                  className="flex items-center gap-4 p-4 bg-gray-50 rounded-lg"
+                >
                   <div className="p-2 bg-blue-100 rounded-lg">
                     <User className="w-5 h-5 text-blue-600" />
                   </div>
                   <div className="flex-1">
-                    <h3 className="font-semibold">{booking.clientName}</h3>
-                    <p className="text-gray-600">{booking.serviceName}</p>
+                    <h3 className="font-semibold">{booking.client}</h3>
+                    <p className="text-gray-600">{booking.service}</p>
                   </div>
                   <div className="text-right">
                     <p className="font-semibold">
                       {booking.date} - {booking.time}
                     </p>
-                    <p className="text-green-600 font-semibold">${booking.price}</p>
+                    <p className="text-green-600 font-semibold">
+                      ${booking.price}
+                    </p>
                   </div>
                   <Badge
                     className={
-                      booking.status === "confirmed"
-                        ? "bg-green-100 text-green-800 hover:bg-green-100"
-                        : "bg-yellow-100 text-yellow-800 hover:bg-yellow-100"
+                      booking.status === 'confirmed'
+                        ? 'bg-green-100 text-green-800 hover:bg-green-100'
+                        : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-100'
                     }
                   >
-                    {booking.status === "confirmed" ? "Confirmada" : "Pendiente"}
+                    {booking.status === 'confirmed'
+                      ? 'Confirmada'
+                      : 'Pendiente'}
                   </Badge>
                 </div>
               ))
@@ -113,5 +130,5 @@ export function Dashboard({ stats, bookings, selectedWorkplace }: DashboardProps
         </CardContent>
       </Card>
     </div>
-  )
+  );
 }

--- a/components/professional/statistics/professional-statistics.tsx
+++ b/components/professional/statistics/professional-statistics.tsx
@@ -1,39 +1,67 @@
-"use client"
+'use client';
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
-import { Badge } from "@/components/ui/badge"
-import { Calendar, DollarSign, TrendingUp, Users, MapPin, Clock, CheckCircle, XCircle, AlertCircle } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import {
+  Calendar,
+  DollarSign,
+  TrendingUp,
+  Users,
+  MapPin,
+  Clock,
+  CheckCircle,
+  XCircle,
+  AlertCircle,
+} from 'lucide-react';
 
 interface ProfessionalStatisticsProps {
-  bookings: any[]
-  services: any[]
-  workplaces: any[]
-  stats: any
+  bookings: any[];
+  services: any[];
+  workplaces: any[];
+  stats: any;
 }
 
-export function ProfessionalStatistics({ bookings, services, workplaces, stats }: ProfessionalStatisticsProps) {
+export function ProfessionalStatistics({
+  bookings,
+  services,
+  workplaces,
+  stats,
+}: ProfessionalStatisticsProps) {
   // Calcular estadísticas detalladas
-  const totalBookings = bookings.length
-  const completedBookings = bookings.filter((b) => b.status === "completed").length
-  const confirmedBookings = bookings.filter((b) => b.status === "confirmed").length
-  const pendingBookings = bookings.filter((b) => b.status === "pending").length
-  const cancelledBookings = bookings.filter((b) => b.status === "cancelled").length
+  const totalBookings = bookings.length;
+  const completedBookings = bookings.filter(
+    (b) => b.status === 'completed'
+  ).length;
+  const confirmedBookings = bookings.filter(
+    (b) => b.status === 'confirmed'
+  ).length;
+  const pendingBookings = bookings.filter((b) => b.status === 'pending').length;
+  const cancelledBookings = bookings.filter(
+    (b) => b.status === 'cancelled'
+  ).length;
 
-  const completionRate = totalBookings > 0 ? (completedBookings / totalBookings) * 100 : 0
-  const confirmationRate = totalBookings > 0 ? (confirmedBookings / totalBookings) * 100 : 0
+  const completionRate =
+    totalBookings > 0 ? (completedBookings / totalBookings) * 100 : 0;
+  const confirmationRate =
+    totalBookings > 0 ? (confirmedBookings / totalBookings) * 100 : 0;
 
-  const totalRevenue = bookings.filter((b) => b.status === "completed").reduce((sum, b) => sum + (b.price || 0), 0)
+  const totalRevenue = bookings
+    .filter((b) => b.status === 'completed')
+    .reduce((sum, b) => sum + (b.price || 0), 0);
 
-  const averageBookingValue = completedBookings > 0 ? totalRevenue / completedBookings : 0
+  const averageBookingValue =
+    completedBookings > 0 ? totalRevenue / completedBookings : 0;
 
   // Estadísticas por servicio
   const serviceStats = services
     .map((service) => {
-      const serviceBookings = bookings.filter((b) => b.serviceId === service.id)
+      const serviceBookings = bookings.filter(
+        (b) => b.serviceId === service.id
+      );
       const serviceRevenue = serviceBookings
-        .filter((b) => b.status === "completed")
-        .reduce((sum, b) => sum + (b.price || 0), 0)
+        .filter((b) => b.status === 'completed')
+        .reduce((sum, b) => sum + (b.price || 0), 0);
 
       return {
         ...service,
@@ -41,19 +69,23 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
         revenue: serviceRevenue,
         completionRate:
           serviceBookings.length > 0
-            ? (serviceBookings.filter((b) => b.status === "completed").length / serviceBookings.length) * 100
+            ? (serviceBookings.filter((b) => b.status === 'completed').length /
+                serviceBookings.length) *
+              100
             : 0,
-      }
+      };
     })
-    .sort((a, b) => b.bookingCount - a.bookingCount)
+    .sort((a, b) => b.bookingCount - a.bookingCount);
 
   // Estadísticas por ubicación
   const workplaceStats = workplaces
     .map((workplace) => {
-      const workplaceBookings = bookings.filter((b) => b.workplaceId === workplace.id)
+      const workplaceBookings = bookings.filter(
+        (b) => b.workplaceId === workplace.id
+      );
       const workplaceRevenue = workplaceBookings
-        .filter((b) => b.status === "completed")
-        .reduce((sum, b) => sum + (b.price || 0), 0)
+        .filter((b) => b.status === 'completed')
+        .reduce((sum, b) => sum + (b.price || 0), 0);
 
       return {
         ...workplace,
@@ -61,17 +93,22 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
         revenue: workplaceRevenue,
         completionRate:
           workplaceBookings.length > 0
-            ? (workplaceBookings.filter((b) => b.status === "completed").length / workplaceBookings.length) * 100
+            ? (workplaceBookings.filter((b) => b.status === 'completed')
+                .length /
+                workplaceBookings.length) *
+              100
             : 0,
-      }
+      };
     })
-    .sort((a, b) => b.bookingCount - a.bookingCount)
+    .sort((a, b) => b.bookingCount - a.bookingCount);
 
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-2xl font-semibold">Estadísticas Profesionales</h2>
-        <p className="text-gray-600">Análisis detallado de tu desempeño y métricas</p>
+        <p className="text-gray-600">
+          Análisis detallado de tu desempeño y métricas
+        </p>
       </div>
 
       {/* Métricas principales */}
@@ -80,8 +117,12 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Total de Citas</p>
-                <p className="text-2xl font-bold text-gray-900">{totalBookings}</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Total de Reservas
+                </p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {totalBookings}
+                </p>
               </div>
               <Calendar className="w-8 h-8 text-blue-500" />
             </div>
@@ -92,8 +133,12 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Ingresos Totales</p>
-                <p className="text-2xl font-bold text-gray-900">${totalRevenue.toLocaleString()}</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Ingresos Totales
+                </p>
+                <p className="text-2xl font-bold text-gray-900">
+                  ${totalRevenue.toLocaleString()}
+                </p>
               </div>
               <DollarSign className="w-8 h-8 text-green-500" />
             </div>
@@ -104,8 +149,12 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Tasa de Finalización</p>
-                <p className="text-2xl font-bold text-gray-900">{completionRate.toFixed(1)}%</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Tasa de Finalización
+                </p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {completionRate.toFixed(1)}%
+                </p>
               </div>
               <TrendingUp className="w-8 h-8 text-purple-500" />
             </div>
@@ -116,8 +165,12 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Valor Promedio</p>
-                <p className="text-2xl font-bold text-gray-900">${averageBookingValue.toFixed(0)}</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Valor Promedio
+                </p>
+                <p className="text-2xl font-bold text-gray-900">
+                  ${averageBookingValue.toFixed(0)}
+                </p>
               </div>
               <Users className="w-8 h-8 text-orange-500" />
             </div>
@@ -141,11 +194,18 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
                 <span className="text-sm font-medium">Completadas</span>
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-600">{completedBookings}</span>
-                <span className="text-sm font-medium">{((completedBookings / totalBookings) * 100).toFixed(1)}%</span>
+                <span className="text-sm text-gray-600">
+                  {completedBookings}
+                </span>
+                <span className="text-sm font-medium">
+                  {((completedBookings / totalBookings) * 100).toFixed(1)}%
+                </span>
               </div>
             </div>
-            <Progress value={(completedBookings / totalBookings) * 100} className="h-2" />
+            <Progress
+              value={(completedBookings / totalBookings) * 100}
+              className="h-2"
+            />
 
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
@@ -153,11 +213,18 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
                 <span className="text-sm font-medium">Confirmadas</span>
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-600">{confirmedBookings}</span>
-                <span className="text-sm font-medium">{((confirmedBookings / totalBookings) * 100).toFixed(1)}%</span>
+                <span className="text-sm text-gray-600">
+                  {confirmedBookings}
+                </span>
+                <span className="text-sm font-medium">
+                  {((confirmedBookings / totalBookings) * 100).toFixed(1)}%
+                </span>
               </div>
             </div>
-            <Progress value={(confirmedBookings / totalBookings) * 100} className="h-2" />
+            <Progress
+              value={(confirmedBookings / totalBookings) * 100}
+              className="h-2"
+            />
 
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
@@ -166,10 +233,15 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
               </div>
               <div className="flex items-center gap-2">
                 <span className="text-sm text-gray-600">{pendingBookings}</span>
-                <span className="text-sm font-medium">{((pendingBookings / totalBookings) * 100).toFixed(1)}%</span>
+                <span className="text-sm font-medium">
+                  {((pendingBookings / totalBookings) * 100).toFixed(1)}%
+                </span>
               </div>
             </div>
-            <Progress value={(pendingBookings / totalBookings) * 100} className="h-2" />
+            <Progress
+              value={(pendingBookings / totalBookings) * 100}
+              className="h-2"
+            />
 
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
@@ -177,11 +249,18 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
                 <span className="text-sm font-medium">Canceladas</span>
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-600">{cancelledBookings}</span>
-                <span className="text-sm font-medium">{((cancelledBookings / totalBookings) * 100).toFixed(1)}%</span>
+                <span className="text-sm text-gray-600">
+                  {cancelledBookings}
+                </span>
+                <span className="text-sm font-medium">
+                  {((cancelledBookings / totalBookings) * 100).toFixed(1)}%
+                </span>
               </div>
             </div>
-            <Progress value={(cancelledBookings / totalBookings) * 100} className="h-2" />
+            <Progress
+              value={(cancelledBookings / totalBookings) * 100}
+              className="h-2"
+            />
           </div>
         </CardContent>
       </Card>
@@ -198,10 +277,15 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
           <CardContent>
             <div className="space-y-4">
               {serviceStats.slice(0, 5).map((service, index) => (
-                <div key={service.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                <div
+                  key={service.id}
+                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                >
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
-                      <span className="font-medium text-sm">{service.name}</span>
+                      <span className="font-medium text-sm">
+                        {service.name}
+                      </span>
                       {index === 0 && (
                         <Badge variant="secondary" className="text-xs">
                           Más Popular
@@ -209,12 +293,18 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
                       )}
                     </div>
                     <div className="text-xs text-gray-600 mt-1">
-                      {service.bookingCount} citas • ${service.revenue.toLocaleString()} ingresos
+                      {service.bookingCount} reservas • $
+                      {service.revenue.toLocaleString()} ingresos
                     </div>
-                    <Progress value={service.completionRate} className="h-1 mt-2" />
+                    <Progress
+                      value={service.completionRate}
+                      className="h-1 mt-2"
+                    />
                   </div>
                   <div className="text-right ml-4">
-                    <div className="text-sm font-medium">{service.completionRate.toFixed(1)}%</div>
+                    <div className="text-sm font-medium">
+                      {service.completionRate.toFixed(1)}%
+                    </div>
                     <div className="text-xs text-gray-500">finalización</div>
                   </div>
                 </div>
@@ -234,10 +324,15 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
           <CardContent>
             <div className="space-y-4">
               {workplaceStats.map((workplace, index) => (
-                <div key={workplace.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                <div
+                  key={workplace.id}
+                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                >
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
-                      <span className="font-medium text-sm">{workplace.name}</span>
+                      <span className="font-medium text-sm">
+                        {workplace.name}
+                      </span>
                       {index === 0 && (
                         <Badge variant="secondary" className="text-xs">
                           Principal
@@ -245,12 +340,18 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
                       )}
                     </div>
                     <div className="text-xs text-gray-600 mt-1">
-                      {workplace.bookingCount} citas • ${workplace.revenue.toLocaleString()} ingresos
+                      {workplace.bookingCount} reservas • $
+                      {workplace.revenue.toLocaleString()} ingresos
                     </div>
-                    <Progress value={workplace.completionRate} className="h-1 mt-2" />
+                    <Progress
+                      value={workplace.completionRate}
+                      className="h-1 mt-2"
+                    />
                   </div>
                   <div className="text-right ml-4">
-                    <div className="text-sm font-medium">{workplace.completionRate.toFixed(1)}%</div>
+                    <div className="text-sm font-medium">
+                      {workplace.completionRate.toFixed(1)}%
+                    </div>
                     <div className="text-xs text-gray-500">finalización</div>
                   </div>
                 </div>
@@ -267,10 +368,18 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
             <div className="flex items-center gap-3">
               <CheckCircle className="w-8 h-8 text-green-500" />
               <div>
-                <p className="text-sm font-medium text-gray-600">Tasa de Finalización</p>
-                <p className="text-xl font-bold text-green-600">{completionRate.toFixed(1)}%</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Tasa de Finalización
+                </p>
+                <p className="text-xl font-bold text-green-600">
+                  {completionRate.toFixed(1)}%
+                </p>
                 <p className="text-xs text-gray-500">
-                  {completionRate >= 80 ? "Excelente" : completionRate >= 60 ? "Bueno" : "Mejorable"}
+                  {completionRate >= 80
+                    ? 'Excelente'
+                    : completionRate >= 60
+                    ? 'Bueno'
+                    : 'Mejorable'}
                 </p>
               </div>
             </div>
@@ -282,9 +391,15 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
             <div className="flex items-center gap-3">
               <AlertCircle className="w-8 h-8 text-yellow-500" />
               <div>
-                <p className="text-sm font-medium text-gray-600">Citas Pendientes</p>
-                <p className="text-xl font-bold text-yellow-600">{pendingBookings}</p>
-                <p className="text-xs text-gray-500">{pendingBookings === 0 ? "Al día" : "Requiere atención"}</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Reservas Pendientes
+                </p>
+                <p className="text-xl font-bold text-yellow-600">
+                  {pendingBookings}
+                </p>
+                <p className="text-xs text-gray-500">
+                  {pendingBookings === 0 ? 'Al día' : 'Requiere atención'}
+                </p>
               </div>
             </div>
           </CardContent>
@@ -295,12 +410,16 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
             <div className="flex items-center gap-3">
               <XCircle className="w-8 h-8 text-red-500" />
               <div>
-                <p className="text-sm font-medium text-gray-600">Tasa de Cancelación</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Tasa de Cancelación
+                </p>
                 <p className="text-xl font-bold text-red-600">
                   {((cancelledBookings / totalBookings) * 100).toFixed(1)}%
                 </p>
                 <p className="text-xs text-gray-500">
-                  {cancelledBookings / totalBookings < 0.1 ? "Excelente" : "Revisar causas"}
+                  {cancelledBookings / totalBookings < 0.1
+                    ? 'Excelente'
+                    : 'Revisar causas'}
                 </p>
               </div>
             </div>
@@ -308,5 +427,5 @@ export function ProfessionalStatistics({ bookings, services, workplaces, stats }
         </Card>
       </div>
     </div>
-  )
+  );
 }

--- a/hooks/use-professional-data.ts
+++ b/hooks/use-professional-data.ts
@@ -1,256 +1,370 @@
-"use client"
+'use client';
 
-import { useState, useEffect } from "react"
-import type { Professional, Workplace, Service, Booking, Client, DashboardStats } from "@/types/professional"
+import { useState, useEffect } from 'react';
+import type {
+  Professional,
+  Workplace,
+  Service,
+  Booking,
+  Client,
+  DashboardStats,
+} from '@/types/professional';
+
+// Temporary types for mock data (more flexible)
+interface MockService {
+  id: string;
+  name: string;
+  description: string;
+  duration: number;
+  price: number;
+  category: string;
+  isActive: boolean;
+  workplaceId: string;
+  schedule: any;
+}
+
+interface MockBooking {
+  id: string;
+  date: string;
+  time: string;
+  service: string;
+  client: string;
+  clientName?: string; // For backward compatibility
+  serviceName?: string; // For backward compatibility
+  status: 'pending' | 'confirmed' | 'completed' | 'cancelled';
+  location: string;
+  duration: string;
+  price: string;
+  workplaceId?: string;
+}
+
+interface MockWorkplace {
+  id: string;
+  name: string;
+  address: string;
+  phone: string | null;
+  email: string | null;
+  schedule?: string; // For mock data
+}
 
 export function useProfessionalData() {
-  const [professional, setProfessional] = useState<Professional | null>(null)
-  const [workplaces, setWorkplaces] = useState<Workplace[]>([])
-  const [services, setServices] = useState<Service[]>([])
-  const [bookings, setBookings] = useState<Booking[]>([])
-  const [clients, setClients] = useState<Client[]>([])
-  const [selectedWorkplace, setSelectedWorkplace] = useState<string>("")
+  const [professional, setProfessional] = useState<Professional | null>(null);
+  const [workplaces, setWorkplaces] = useState<Workplace[]>([]);
+  const [services, setServices] = useState<Service[]>([]);
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [clients, setClients] = useState<Client[]>([]);
+  const [selectedWorkplace, setSelectedWorkplace] = useState<string>('');
 
   useEffect(() => {
     // Simular carga de datos
-    loadMockData()
-  }, [])
+    loadMockData();
+  }, []);
 
   const loadMockData = () => {
     const mockProfessional: Professional = {
-      id: "1",
-      name: "Dr. Juan Pérez",
-      title: "Médico General",
-      email: "doctor@clinica.com",
-      phone: "+1234567890",
-      licenseNumber: "MP-1234",
+      id: '1',
+      name: 'Dr. Juan Pérez',
+      title: 'Médico General',
+      email: 'doctor@clinica.com',
+      phone: '+1234567890',
+      licenseNumber: 'MP-1234',
       experience: 15,
-      education: "Universidad Nacional - Medicina",
-      specialties: ["Medicina General", "Medicina Preventiva"],
+      education: 'Universidad Nacional - Medicina',
+      specialties: ['Medicina General', 'Medicina Preventiva'],
       biography:
-        "Médico especializado en medicina general con amplia experiencia en diagnóstico y tratamiento de diversas patologías.",
+        'Médico especializado en medicina general con amplia experiencia en diagnóstico y tratamiento de diversas patologías.',
       rating: 4.8,
       totalBookings: 156,
-      memberSince: "Enero 2023",
+      memberSince: 'Enero 2023',
       workplaces: [],
-    }
+    };
 
     const mockWorkplaces: Workplace[] = [
       {
-        id: "1",
-        name: "Clínica Centro",
-        address: "Av. Principal 123, Centro, Ciudad",
-        description: "Nuestra sede principal ubicada en el centro de la ciudad",
-        phone: "+1234567890",
-        email: "centro@clinica.com",
-        schedule: "08:00 - 18:00",
-        services: ["Consulta Médica General", "Consulta Nutricional"],
+        id: '1',
+        name: 'Clínica Centro',
+        address: 'Av. Principal 123, Centro, Ciudad',
+        description: 'Nuestra sede principal ubicada en el centro de la ciudad',
+        phone: '+1234567890',
+        email: 'centro@clinica.com',
+        schedule: '08:00 - 18:00',
+        services: ['Consulta Médica General', 'Consulta Nutricional'],
         isActive: true,
       },
       {
-        id: "2",
-        name: "Centro Rehabilitación",
-        address: "Calle Salud 456, Norte, Ciudad",
-        description: "Centro especializado en terapias de rehabilitación",
-        phone: "+1234567891",
-        email: "rehabilitacion@clinica.com",
-        schedule: "07:00 - 19:00",
-        services: ["Terapia Física"],
+        id: '2',
+        name: 'Centro Rehabilitación',
+        address: 'Calle Salud 456, Norte, Ciudad',
+        description: 'Centro especializado en terapias de rehabilitación',
+        phone: '+1234567891',
+        email: 'rehabilitacion@clinica.com',
+        schedule: '07:00 - 19:00',
+        services: ['Terapia Física'],
         isActive: true,
       },
       {
-        id: "3",
-        name: "Laboratorio Central",
-        address: "Plaza Médica 789, Sur, Ciudad",
-        description: "Laboratorio clínico con equipos de última generación",
-        phone: "+1234567892",
-        email: "laboratorio@clinica.com",
-        schedule: "06:00 - 14:00",
-        services: ["Exámenes de Laboratorio"],
+        id: '3',
+        name: 'Laboratorio Central',
+        address: 'Plaza Médica 789, Sur, Ciudad',
+        description: 'Laboratorio clínico con equipos de última generación',
+        phone: '+1234567892',
+        email: 'laboratorio@clinica.com',
+        schedule: '06:00 - 14:00',
+        services: ['Exámenes de Laboratorio'],
         isActive: true,
       },
-    ]
+    ];
 
     const mockServices: Service[] = [
       {
-        id: "1",
-        name: "Consulta Médica General",
-        description: "Consulta médica integral con revisión completa del estado de salud",
+        id: '1',
+        name: 'Consulta Médica General',
+        description:
+          'Consulta médica integral con revisión completa del estado de salud',
         duration: 30,
         price: 150,
-        category: "Medicina General",
+        category: 'Medicina General',
         isActive: true,
-        workplaceId: "1",
+        workplaceId: '1',
         schedule: {
-          monday: { isAvailable: true, startTime: "08:00", endTime: "17:00", breakStart: "12:00", breakEnd: "13:00" },
-          tuesday: { isAvailable: true, startTime: "08:00", endTime: "17:00", breakStart: "12:00", breakEnd: "13:00" },
+          monday: {
+            isAvailable: true,
+            startTime: '08:00',
+            endTime: '17:00',
+            breakStart: '12:00',
+            breakEnd: '13:00',
+          },
+          tuesday: {
+            isAvailable: true,
+            startTime: '08:00',
+            endTime: '17:00',
+            breakStart: '12:00',
+            breakEnd: '13:00',
+          },
           wednesday: {
             isAvailable: true,
-            startTime: "08:00",
-            endTime: "17:00",
-            breakStart: "12:00",
-            breakEnd: "13:00",
+            startTime: '08:00',
+            endTime: '17:00',
+            breakStart: '12:00',
+            breakEnd: '13:00',
           },
-          thursday: { isAvailable: true, startTime: "08:00", endTime: "17:00", breakStart: "12:00", breakEnd: "13:00" },
-          friday: { isAvailable: true, startTime: "08:00", endTime: "17:00", breakStart: "12:00", breakEnd: "13:00" },
-          saturday: { isAvailable: true, startTime: "08:00", endTime: "12:00" },
-          sunday: { isAvailable: false, startTime: "", endTime: "" },
+          thursday: {
+            isAvailable: true,
+            startTime: '08:00',
+            endTime: '17:00',
+            breakStart: '12:00',
+            breakEnd: '13:00',
+          },
+          friday: {
+            isAvailable: true,
+            startTime: '08:00',
+            endTime: '17:00',
+            breakStart: '12:00',
+            breakEnd: '13:00',
+          },
+          saturday: { isAvailable: true, startTime: '08:00', endTime: '12:00' },
+          sunday: { isAvailable: false, startTime: '', endTime: '' },
         },
       },
       {
-        id: "2",
-        name: "Chequeo Médico Completo",
-        description: "Evaluación médica exhaustiva con análisis de laboratorio incluidos",
+        id: '2',
+        name: 'Chequeo Médico Completo',
+        description:
+          'Evaluación médica exhaustiva con análisis de laboratorio incluidos',
         duration: 60,
         price: 300,
-        category: "Medicina General",
+        category: 'Medicina General',
         isActive: true,
-        workplaceId: "1",
+        workplaceId: '1',
         schedule: {
-          monday: { isAvailable: true, startTime: "09:00", endTime: "16:00", breakStart: "12:00", breakEnd: "13:00" },
-          tuesday: { isAvailable: true, startTime: "09:00", endTime: "16:00", breakStart: "12:00", breakEnd: "13:00" },
-          wednesday: { isAvailable: false, startTime: "", endTime: "" },
-          thursday: { isAvailable: true, startTime: "09:00", endTime: "16:00", breakStart: "12:00", breakEnd: "13:00" },
-          friday: { isAvailable: true, startTime: "09:00", endTime: "16:00", breakStart: "12:00", breakEnd: "13:00" },
-          saturday: { isAvailable: false, startTime: "", endTime: "" },
-          sunday: { isAvailable: false, startTime: "", endTime: "" },
+          monday: {
+            isAvailable: true,
+            startTime: '09:00',
+            endTime: '16:00',
+            breakStart: '12:00',
+            breakEnd: '13:00',
+          },
+          tuesday: {
+            isAvailable: true,
+            startTime: '09:00',
+            endTime: '16:00',
+            breakStart: '12:00',
+            breakEnd: '13:00',
+          },
+          wednesday: { isAvailable: false, startTime: '', endTime: '' },
+          thursday: {
+            isAvailable: true,
+            startTime: '09:00',
+            endTime: '16:00',
+            breakStart: '12:00',
+            breakEnd: '13:00',
+          },
+          friday: {
+            isAvailable: true,
+            startTime: '09:00',
+            endTime: '16:00',
+            breakStart: '12:00',
+            breakEnd: '13:00',
+          },
+          saturday: { isAvailable: false, startTime: '', endTime: '' },
+          sunday: { isAvailable: false, startTime: '', endTime: '' },
         },
       },
       {
-        id: "3",
-        name: "Consulta Nutricional",
-        description: "Evaluación nutricional y plan alimentario personalizado",
+        id: '3',
+        name: 'Consulta Nutricional',
+        description: 'Evaluación nutricional y plan alimentario personalizado',
         duration: 45,
         price: 120,
-        category: "Nutrición",
+        category: 'Nutrición',
         isActive: true,
-        workplaceId: "1",
+        workplaceId: '1',
         schedule: {
-          monday: { isAvailable: true, startTime: "14:00", endTime: "18:00" },
-          tuesday: { isAvailable: true, startTime: "14:00", endTime: "18:00" },
-          wednesday: { isAvailable: true, startTime: "14:00", endTime: "18:00" },
-          thursday: { isAvailable: true, startTime: "14:00", endTime: "18:00" },
-          friday: { isAvailable: true, startTime: "14:00", endTime: "18:00" },
-          saturday: { isAvailable: false, startTime: "", endTime: "" },
-          sunday: { isAvailable: false, startTime: "", endTime: "" },
+          monday: { isAvailable: true, startTime: '14:00', endTime: '18:00' },
+          tuesday: { isAvailable: true, startTime: '14:00', endTime: '18:00' },
+          wednesday: {
+            isAvailable: true,
+            startTime: '14:00',
+            endTime: '18:00',
+          },
+          thursday: { isAvailable: true, startTime: '14:00', endTime: '18:00' },
+          friday: { isAvailable: true, startTime: '14:00', endTime: '18:00' },
+          saturday: { isAvailable: false, startTime: '', endTime: '' },
+          sunday: { isAvailable: false, startTime: '', endTime: '' },
         },
       },
-    ]
+    ];
 
     const mockBookings: Booking[] = [
       {
-        id: "1",
-        clientId: "1",
-        clientName: "María García",
-        clientEmail: "maria.garcia@email.com",
-        clientPhone: "+1234567890",
-        serviceId: "1",
-        serviceName: "Consulta Médica General",
-        date: "2025-01-15",
-        time: "10:00",
+        id: '1',
+        clientId: '1',
+        clientName: 'María García',
+        clientEmail: 'maria.garcia@email.com',
+        clientPhone: '+1234567890',
+        serviceId: '1',
+        serviceName: 'Consulta Médica General',
+        date: '2025-01-15',
+        time: '10:00',
         duration: 30,
         price: 150,
-        status: "confirmed",
-        workplaceId: "1",
-        workplaceName: "Clínica Centro",
-        notes: "Primera consulta",
+        status: 'confirmed',
+        workplaceId: '1',
+        workplaceName: 'Clínica Centro',
+        notes: 'Primera consulta',
       },
       {
-        id: "2",
-        clientId: "2",
-        clientName: "Carlos López",
-        clientEmail: "carlos.lopez@email.com",
-        clientPhone: "+1234567891",
-        serviceId: "2",
-        serviceName: "Chequeo Médico Completo",
-        date: "2025-01-15",
-        time: "14:30",
+        id: '2',
+        clientId: '2',
+        clientName: 'Carlos López',
+        clientEmail: 'carlos.lopez@email.com',
+        clientPhone: '+1234567891',
+        serviceId: '2',
+        serviceName: 'Chequeo Médico Completo',
+        date: '2025-01-15',
+        time: '14:30',
         duration: 60,
         price: 300,
-        status: "pending",
-        workplaceId: "1",
-        workplaceName: "Clínica Centro",
+        status: 'pending',
+        workplaceId: '1',
+        workplaceName: 'Clínica Centro',
       },
-    ]
+    ];
 
     const mockClients: Client[] = [
       {
-        id: "1",
-        name: "María García",
-        email: "maria.garcia@email.com",
-        phone: "+1234567890",
-        createdAt: "2024-12-01",
+        id: '1',
+        name: 'María García',
+        email: 'maria.garcia@email.com',
+        phone: '+1234567890',
+        createdAt: '2024-12-01',
       },
       {
-        id: "2",
-        name: "Carlos López",
-        email: "carlos.lopez@email.com",
-        phone: "+1234567891",
-        createdAt: "2024-11-15",
+        id: '2',
+        name: 'Carlos López',
+        email: 'carlos.lopez@email.com',
+        phone: '+1234567891',
+        createdAt: '2024-11-15',
       },
       {
-        id: "3",
-        name: "Ana Martínez",
-        email: "ana.martinez@email.com",
-        phone: "+1234567892",
-        createdAt: "2024-10-20",
+        id: '3',
+        name: 'Ana Martínez',
+        email: 'ana.martinez@email.com',
+        phone: '+1234567892',
+        createdAt: '2024-10-20',
       },
-    ]
+    ];
 
-    setProfessional(mockProfessional)
-    setWorkplaces(mockWorkplaces)
-    setServices(mockServices)
-    setBookings(mockBookings)
-    setClients(mockClients)
-    setSelectedWorkplace("1")
-  }
+    setProfessional(mockProfessional);
+    setWorkplaces(mockWorkplaces);
+    setServices(mockServices);
+    setBookings(mockBookings);
+    setClients(mockClients);
+    setSelectedWorkplace('1');
+  };
 
   const getDashboardStats = (): DashboardStats => {
-    const today = new Date().toISOString().split("T")[0]
-    const todayBookings = bookings.filter((b) => b.date === today)
-    const pendingBookings = bookings.filter((b) => b.status === "pending")
+    const today = new Date().toISOString().split('T')[0];
+    const todayBookings = bookings.filter((b) => b.date === today);
+    const pendingBookings = bookings.filter((b) => b.status === 'pending');
+    const weeklyBookings = bookings.filter((b) => {
+      const bookingDate = new Date(b.date);
+      const startOfWeek = new Date();
+      startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay());
+      const endOfWeek = new Date(startOfWeek);
+      endOfWeek.setDate(startOfWeek.getDate() + 6);
+      return bookingDate >= startOfWeek && bookingDate <= endOfWeek;
+    });
 
     return {
-      todayAppointments: todayBookings.length,
+      todayBookings: todayBookings.length,
       pendingBookings: pendingBookings.length,
-      weeklyAppointments: 32, // Mock data
+      weeklyBookings: weeklyBookings.length,
       monthlyRevenue: 4800, // Mock data
-    }
-  }
+    };
+  };
 
-  const addService = (service: Omit<Service, "id">) => {
+  const addService = (service: Omit<Service, 'id'>) => {
     const newService: Service = {
       ...service,
       id: Date.now().toString(),
-    }
-    setServices((prev) => [...prev, newService])
-  }
+    };
+    setServices((prev) => [...prev, newService]);
+  };
 
   const updateService = (id: string, updates: Partial<Service>) => {
-    setServices((prev) => prev.map((service) => (service.id === id ? { ...service, ...updates } : service)))
-  }
+    setServices((prev) =>
+      prev.map((service) =>
+        service.id === id ? { ...service, ...updates } : service
+      )
+    );
+  };
 
-  const addClient = (client: Omit<Client, "id" | "createdAt">) => {
+  const addClient = (client: Omit<Client, 'id' | 'createdAt'>) => {
     const newClient: Client = {
       ...client,
       id: Date.now().toString(),
       createdAt: new Date().toISOString(),
-    }
-    setClients((prev) => [...prev, newClient])
-    return newClient
-  }
+    };
+    setClients((prev) => [...prev, newClient]);
+    return newClient;
+  };
 
-  const addBooking = (booking: Omit<Booking, "id">) => {
+  const addBooking = (booking: Omit<Booking, 'id'>) => {
     const newBooking: Booking = {
       ...booking,
       id: Date.now().toString(),
-    }
-    setBookings((prev) => [...prev, newBooking])
-  }
+    };
+    setBookings((prev) => [...prev, newBooking]);
+  };
 
-  const updateBookingStatus = (id: string, status: Booking["status"]) => {
-    setBookings((prev) => prev.map((booking) => (booking.id === id ? { ...booking, status } : booking)))
-  }
+  const updateBookingStatus = (id: string, status: Booking['status']) => {
+    setBookings((prev) =>
+      prev.map((booking) =>
+        booking.id === id ? { ...booking, status } : booking
+      )
+    );
+  };
 
   return {
     professional,
@@ -266,5 +380,5 @@ export function useProfessionalData() {
     addClient,
     addBooking,
     updateBookingStatus,
-  }
+  };
 }

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1,319 +1,439 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
 
 export interface Database {
   public: {
     Tables: {
       profiles: {
         Row: {
-          id: string
-          email: string
-          full_name: string | null
-          phone: string | null
-          user_type: "Cliente" | "Profesional" | "Empresa"
-          avatar_url: string | null
-          created_at: string
-          updated_at: string
-        }
+          id: string;
+          email: string;
+          full_name: string | null;
+          phone: string | null;
+          user_type: 'Cliente' | 'Profesional' | 'Empresa';
+          avatar_url: string | null;
+          created_at: string;
+          updated_at: string;
+        };
         Insert: {
-          id: string
-          email: string
-          full_name?: string | null
-          phone?: string | null
-          user_type?: "Cliente" | "Profesional" | "Empresa"
-          avatar_url?: string | null
-          created_at?: string
-          updated_at?: string
-        }
+          id: string;
+          email: string;
+          full_name?: string | null;
+          phone?: string | null;
+          user_type?: 'Cliente' | 'Profesional' | 'Empresa';
+          avatar_url?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
         Update: {
-          id?: string
-          email?: string
-          full_name?: string | null
-          phone?: string | null
-          user_type?: "Cliente" | "Profesional" | "Empresa"
-          avatar_url?: string | null
-          created_at?: string
-          updated_at?: string
-        }
-      }
+          id?: string;
+          email?: string;
+          full_name?: string | null;
+          phone?: string | null;
+          user_type?: 'Cliente' | 'Profesional' | 'Empresa';
+          avatar_url?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
       companies: {
         Row: {
-          id: string
-          user_id: string
-          name: string
-          email: string
-          phone: string | null
-          address: string | null
-          website: string | null
-          description: string | null
-          logo_url: string | null
-          capacity: number | null
-          founded_year: number | null
-          rating: number
-          total_bookings: number
-          monthly_revenue: number
-          is_active: boolean
-          created_at: string
-          updated_at: string
-        }
+          id: string;
+          user_id: string;
+          name: string;
+          email: string;
+          phone: string | null;
+          address: string | null;
+          website: string | null;
+          description: string | null;
+          logo_url: string | null;
+          capacity: number | null;
+          founded_year: number | null;
+          rating: number;
+          total_bookings: number;
+          monthly_revenue: number;
+          is_active: boolean;
+          created_at: string;
+          updated_at: string;
+        };
         Insert: {
-          id?: string
-          user_id: string
-          name: string
-          email: string
-          phone?: string | null
-          address?: string | null
-          website?: string | null
-          description?: string | null
-          logo_url?: string | null
-          capacity?: number | null
-          founded_year?: number | null
-          rating?: number
-          total_bookings?: number
-          monthly_revenue?: number
-          is_active?: boolean
-          created_at?: string
-          updated_at?: string
-        }
+          id?: string;
+          user_id: string;
+          name: string;
+          email: string;
+          phone?: string | null;
+          address?: string | null;
+          website?: string | null;
+          description?: string | null;
+          logo_url?: string | null;
+          capacity?: number | null;
+          founded_year?: number | null;
+          rating?: number;
+          total_bookings?: number;
+          monthly_revenue?: number;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
         Update: {
-          id?: string
-          user_id?: string
-          name?: string
-          email?: string
-          phone?: string | null
-          address?: string | null
-          website?: string | null
-          description?: string | null
-          logo_url?: string | null
-          capacity?: number | null
-          founded_year?: number | null
-          rating?: number
-          total_bookings?: number
-          monthly_revenue?: number
-          is_active?: boolean
-          created_at?: string
-          updated_at?: string
-        }
-      }
+          id?: string;
+          user_id?: string;
+          name?: string;
+          email?: string;
+          phone?: string | null;
+          address?: string | null;
+          website?: string | null;
+          description?: string | null;
+          logo_url?: string | null;
+          capacity?: number | null;
+          founded_year?: number | null;
+          rating?: number;
+          total_bookings?: number;
+          monthly_revenue?: number;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
       professionals: {
         Row: {
-          id: string
-          user_id: string
-          company_id: string | null
-          name: string
-          title: string
-          email: string
-          phone: string | null
-          license_number: string | null
-          experience: number | null
-          education: string | null
-          specialties: string[]
-          biography: string | null
-          avatar_url: string | null
-          rating: number
-          total_bookings: number
-          monthly_revenue: number
-          is_active: boolean
-          created_at: string
-          updated_at: string
-        }
+          id: string;
+          user_id: string;
+          company_id: string | null;
+          name: string;
+          title: string;
+          email: string;
+          phone: string | null;
+          license_number: string | null;
+          experience: number | null;
+          education: string | null;
+          specialties: string[];
+          biography: string | null;
+          avatar_url: string | null;
+          rating: number;
+          total_bookings: number;
+          monthly_revenue: number;
+          is_active: boolean;
+          created_at: string;
+          updated_at: string;
+        };
         Insert: {
-          id?: string
-          user_id: string
-          company_id?: string | null
-          name: string
-          title: string
-          email: string
-          phone?: string | null
-          license_number?: string | null
-          experience?: number | null
-          education?: string | null
-          specialties?: string[]
-          biography?: string | null
-          avatar_url?: string | null
-          rating?: number
-          total_bookings?: number
-          monthly_revenue?: number
-          is_active?: boolean
-          created_at?: string
-          updated_at?: string
-        }
+          id?: string;
+          user_id: string;
+          company_id?: string | null;
+          name: string;
+          title: string;
+          email: string;
+          phone?: string | null;
+          license_number?: string | null;
+          experience?: number | null;
+          education?: string | null;
+          specialties?: string[];
+          biography?: string | null;
+          avatar_url?: string | null;
+          rating?: number;
+          total_bookings?: number;
+          monthly_revenue?: number;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
         Update: {
-          id?: string
-          user_id?: string
-          company_id?: string | null
-          name?: string
-          title?: string
-          email?: string
-          phone?: string | null
-          license_number?: string | null
-          experience?: number | null
-          education?: string | null
-          specialties?: string[]
-          biography?: string | null
-          avatar_url?: string | null
-          rating?: number
-          total_bookings?: number
-          monthly_revenue?: number
-          is_active?: boolean
-          created_at?: string
-          updated_at?: string
-        }
-      }
+          id?: string;
+          user_id?: string;
+          company_id?: string | null;
+          name?: string;
+          title?: string;
+          email?: string;
+          phone?: string | null;
+          license_number?: string | null;
+          experience?: number | null;
+          education?: string | null;
+          specialties?: string[];
+          biography?: string | null;
+          avatar_url?: string | null;
+          rating?: number;
+          total_bookings?: number;
+          monthly_revenue?: number;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
       workplaces: {
         Row: {
-          id: string
-          company_id: string | null
-          name: string
-          address: string
-          description: string | null
-          phone: string | null
-          email: string | null
-          is_active: boolean
-          created_at: string
-          updated_at: string
-        }
+          id: string;
+          company_id: string | null;
+          name: string;
+          address: string;
+          description: string | null;
+          phone: string | null;
+          email: string | null;
+          is_active: boolean;
+          created_at: string;
+          updated_at: string;
+        };
         Insert: {
-          id?: string
-          company_id?: string | null
-          name: string
-          address: string
-          description?: string | null
-          phone?: string | null
-          email?: string | null
-          is_active?: boolean
-          created_at?: string
-          updated_at?: string
-        }
+          id?: string;
+          company_id?: string | null;
+          name: string;
+          address: string;
+          description?: string | null;
+          phone?: string | null;
+          email?: string | null;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
         Update: {
-          id?: string
-          company_id?: string | null
-          name?: string
-          address?: string
-          description?: string | null
-          phone?: string | null
-          email?: string | null
-          is_active?: boolean
-          created_at?: string
-          updated_at?: string
-        }
-      }
+          id?: string;
+          company_id?: string | null;
+          name?: string;
+          address?: string;
+          description?: string | null;
+          phone?: string | null;
+          email?: string | null;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
       services: {
         Row: {
-          id: string
-          professional_id: string
-          workplace_id: string
-          name: string
-          description: string | null
-          duration: number
-          price: number
-          category: string | null
-          is_active: boolean
-          created_at: string
-          updated_at: string
-        }
+          id: string;
+          professional_id: string;
+          workplace_id: string;
+          name: string;
+          description: string | null;
+          duration: number;
+          price: number;
+          category: string | null;
+          schedule: Record<string, any> | null; // JSONB schedule
+          tags: string[] | null;
+          requirements: string | null;
+          preparation_time: number;
+          cleanup_time: number;
+          max_bookings_per_day: number;
+          booking_window_days: number;
+          image_url: string | null;
+          color: string;
+          is_active: boolean;
+          created_at: string;
+          updated_at: string;
+        };
         Insert: {
-          id?: string
-          professional_id: string
-          workplace_id: string
-          name: string
-          description?: string | null
-          duration: number
-          price: number
-          category?: string | null
-          is_active?: boolean
-          created_at?: string
-          updated_at?: string
-        }
+          id?: string;
+          professional_id: string;
+          workplace_id: string;
+          name: string;
+          description?: string | null;
+          duration: number;
+          price: number;
+          category?: string | null;
+          schedule?: Record<string, any> | null;
+          tags?: string[] | null;
+          requirements?: string | null;
+          preparation_time?: number;
+          cleanup_time?: number;
+          max_bookings_per_day?: number;
+          booking_window_days?: number;
+          image_url?: string | null;
+          color?: string;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
         Update: {
-          id?: string
-          professional_id?: string
-          workplace_id?: string
-          name?: string
-          description?: string | null
-          duration?: number
-          price?: number
-          category?: string | null
-          is_active?: boolean
-          created_at?: string
-          updated_at?: string
-        }
-      }
+          id?: string;
+          professional_id?: string;
+          workplace_id?: string;
+          name?: string;
+          description?: string | null;
+          duration?: number;
+          price?: number;
+          category?: string | null;
+          schedule?: Record<string, any> | null;
+          tags?: string[] | null;
+          requirements?: string | null;
+          preparation_time?: number;
+          cleanup_time?: number;
+          max_bookings_per_day?: number;
+          booking_window_days?: number;
+          image_url?: string | null;
+          color?: string;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
       bookings: {
         Row: {
-          id: string
-          client_id: string
-          professional_id: string
-          service_id: string
-          workplace_id: string
-          date: string
-          time: string
-          duration: number
-          price: number
-          status: "pending" | "confirmed" | "completed" | "cancelled"
-          notes: string | null
-          created_at: string
-          updated_at: string
-        }
+          id: string;
+          client_id: string;
+          professional_id: string;
+          service_id: string;
+          workplace_id: string;
+          company_id: string | null;
+          booking_date: string;
+          booking_time: string;
+          duration: number;
+          price: number;
+          status:
+            | 'pending'
+            | 'confirmed'
+            | 'completed'
+            | 'cancelled'
+            | 'no_show';
+          notes: string | null;
+          instructions: string | null;
+          description: string | null;
+          cancellation_reason: string | null;
+          payment_status: 'pending' | 'paid' | 'refunded';
+          payment_method: string | null;
+          created_at: string;
+          updated_at: string;
+        };
         Insert: {
-          id?: string
-          client_id: string
-          professional_id: string
-          service_id: string
-          workplace_id: string
-          date: string
-          time: string
-          duration: number
-          price: number
-          status?: "pending" | "confirmed" | "completed" | "cancelled"
-          notes?: string | null
-          created_at?: string
-          updated_at?: string
-        }
+          id?: string;
+          client_id: string;
+          professional_id: string;
+          service_id: string;
+          workplace_id: string;
+          company_id?: string | null;
+          booking_date: string;
+          booking_time: string;
+          duration: number;
+          price: number;
+          status?:
+            | 'pending'
+            | 'confirmed'
+            | 'completed'
+            | 'cancelled'
+            | 'no_show';
+          notes?: string | null;
+          instructions?: string | null;
+          description?: string | null;
+          cancellation_reason?: string | null;
+          payment_status?: 'pending' | 'paid' | 'refunded';
+          payment_method?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
         Update: {
-          id?: string
-          client_id?: string
-          professional_id?: string
-          service_id?: string
-          workplace_id?: string
-          date?: string
-          time?: string
-          duration?: number
-          price?: number
-          status?: "pending" | "confirmed" | "completed" | "cancelled"
-          notes?: string | null
-          created_at?: string
-          updated_at?: string
-        }
-      }
+          id?: string;
+          client_id?: string;
+          professional_id?: string;
+          service_id?: string;
+          workplace_id?: string;
+          company_id?: string | null;
+          booking_date?: string;
+          booking_time?: string;
+          duration?: number;
+          price?: number;
+          status?:
+            | 'pending'
+            | 'confirmed'
+            | 'completed'
+            | 'cancelled'
+            | 'no_show';
+          notes?: string | null;
+          instructions?: string | null;
+          description?: string | null;
+          cancellation_reason?: string | null;
+          payment_status?: 'pending' | 'paid' | 'refunded';
+          payment_method?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
       clients: {
         Row: {
-          id: string
-          user_id: string | null
-          name: string
-          email: string
-          phone: string | null
-          created_at: string
-          updated_at: string
-        }
+          id: string;
+          user_id: string | null;
+          name: string;
+          email: string;
+          phone: string | null;
+          date_of_birth: string | null;
+          address: string | null;
+          emergency_contact: {
+            name: string;
+            phone: string;
+            relationship: string;
+          } | null;
+          medical_history: string[] | null;
+          allergies: string[] | null;
+          current_medications: string[] | null;
+          insurance_provider: string | null;
+          insurance_number: string | null;
+          preferred_language: string | null;
+          communication_preferences: {
+            email: boolean;
+            sms: boolean;
+            phone: boolean;
+          } | null;
+          created_at: string;
+          updated_at: string;
+        };
         Insert: {
-          id?: string
-          user_id?: string | null
-          name: string
-          email: string
-          phone?: string | null
-          created_at?: string
-          updated_at?: string
-        }
+          id?: string;
+          user_id?: string | null;
+          name: string;
+          email: string;
+          phone?: string | null;
+          date_of_birth?: string | null;
+          address?: string | null;
+          emergency_contact?: {
+            name: string;
+            phone: string;
+            relationship: string;
+          } | null;
+          medical_history?: string[] | null;
+          allergies?: string[] | null;
+          current_medications?: string[] | null;
+          insurance_provider?: string | null;
+          insurance_number?: string | null;
+          preferred_language?: string | null;
+          communication_preferences?: {
+            email: boolean;
+            sms: boolean;
+            phone: boolean;
+          } | null;
+          created_at?: string;
+          updated_at?: string;
+        };
         Update: {
-          id?: string
-          user_id?: string | null
-          name?: string
-          email?: string
-          phone?: string | null
-          created_at?: string
-          updated_at?: string
-        }
-      }
-    }
-  }
+          id?: string;
+          user_id?: string | null;
+          name?: string;
+          email?: string;
+          phone?: string | null;
+          date_of_birth?: string | null;
+          address?: string | null;
+          emergency_contact?: {
+            name: string;
+            phone: string;
+            relationship: string;
+          } | null;
+          medical_history?: string[] | null;
+          allergies?: string[] | null;
+          current_medications?: string[] | null;
+          insurance_provider?: string | null;
+          insurance_number?: string | null;
+          preferred_language?: string | null;
+          communication_preferences?: {
+            email: boolean;
+            sms: boolean;
+            phone: boolean;
+          } | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
+    };
+  };
 }

--- a/lib/stores/client-store.ts
+++ b/lib/stores/client-store.ts
@@ -1,129 +1,59 @@
-import { create } from "zustand"
-import { persist } from "zustand/middleware"
-import type { Profile } from "@/lib/stores/auth-store"
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Profile } from '@/types/auth';
+import type {
+  ClientProfile,
+  ClientBooking,
+  AvailableService,
+  BookingHistory,
+} from '@/types/client';
 import {
   getMockClientProfile,
   getMockUpcomingBookings,
   getMockPastBookings,
   getMockAvailableServices,
   getMockBookingHistory,
-} from "@/lib/mock-data/client-data"
+} from '@/lib/mock-data/client-data';
 
-export interface ClientProfile {
-  id: string
-  name: string
-  email: string
-  phone: string
-  date_of_birth?: string
-  address?: string
-  emergency_contact?: {
-    name: string
-    phone: string
-    relationship: string
-  }
-  medical_history?: string[]
-  allergies?: string[]
-  current_medications?: string[]
-  insurance_provider?: string
-  insurance_number?: string
-  preferred_language?: string
-  communication_preferences?: {
-    email: boolean
-    sms: boolean
-    phone: boolean
-  }
-  avatar_url?: string
-  created_at: string
-}
-
-export interface ClientBooking {
-  id: string
-  date: string
-  professional: string
-  clinic: string
-  status: "confirmed" | "pending" | "cancelled"
-}
-
-export interface AvailableService {
-  id: string
-  name: string
-  description: string
-  category: string
-  duration: number
-  price: number
-  professional: {
-    id: string
-    name: string
-    specialty: string
-    rating: number
-    avatar_url?: string
-  }
-  location: {
-    id: string
-    name: string
-    address: string
-    phone: string
-  }
-  available_slots: Array<{
-    date: string
-    times: string[]
-  }>
-  is_popular: boolean
-  tags: string[]
-}
-
-export interface BookingHistory {
-  total_bookings: number
-  completed_bookings: number
-  cancelled_bookings: number
-  no_show_bookings: number
-  total_spent: number
-  average_rating_given: number
-  favorite_professional?: string
-  most_booked_service?: string
-  first_booking_date?: string
-  last_booking_date?: string
-}
-
-export type ClientTab = "dashboard" | "bookings" | "history" | "profile"
+export type ClientTab = 'dashboard' | 'bookings' | 'history' | 'profile';
 
 interface ClientState {
   // Current state
-  activeTab: ClientTab
+  activeTab: ClientTab;
 
   // Data
-  profile: Profile | null
-  upcomingBookings: ClientBooking[]
-  pastBookings: ClientBooking[]
-  availableServices: AvailableService[]
-  bookingHistory: BookingHistory
+  profile: ClientProfile | null;
+  upcomingBookings: ClientBooking[];
+  pastBookings: ClientBooking[];
+  availableServices: AvailableService[];
+  bookingHistory: BookingHistory;
 
   // UI state
-  isBookingModalOpen: boolean
-  selectedService: AvailableService | null
+  isBookingModalOpen: boolean;
+  selectedService: AvailableService | null;
 
   // Actions
-  setActiveTab: (tab: ClientTab) => void
-  setProfile: (profile: Profile) => void
+  setActiveTab: (tab: ClientTab) => void;
+  setProfile: (profile: ClientProfile | null) => void;
 
   // Booking actions
-  addBooking: (booking: ClientBooking) => void
-  updateBookingStatus: (id: string, status: ClientBooking["status"]) => void
-  cancelBooking: (id: string) => void
+  addBooking: (booking: ClientBooking) => void;
+  updateBookingStatus: (id: string, status: ClientBooking['status']) => void;
+  cancelBooking: (id: string) => void;
 
   // Service actions
-  setSelectedService: (service: AvailableService | null) => void
-  setBookingModalOpen: (open: boolean) => void
+  setSelectedService: (service: AvailableService | null) => void;
+  setBookingModalOpen: (open: boolean) => void;
 
   // Load data
-  loadData: () => void
+  loadData: () => void;
 }
 
 export const useClientStore = create<ClientState>()(
   persist(
     (set, get) => ({
       // Initial state
-      activeTab: "dashboard",
+      activeTab: 'dashboard',
 
       // Initial data
       profile: null,
@@ -148,11 +78,14 @@ export const useClientStore = create<ClientState>()(
       setProfile: (profile) => set({ profile }),
 
       // Booking actions
-      addBooking: (booking) => set((s) => ({ upcomingBookings: [booking, ...s.upcomingBookings] })),
+      addBooking: (booking) =>
+        set((s) => ({ upcomingBookings: [booking, ...s.upcomingBookings] })),
 
       updateBookingStatus: (id, status) =>
         set((s) => ({
-          upcomingBookings: s.upcomingBookings.map((b) => (b.id === id ? { ...b, status } : b)),
+          upcomingBookings: s.upcomingBookings.map((b) =>
+            b.id === id ? { ...b, status } : b
+          ),
         })),
 
       cancelBooking: (id) =>
@@ -162,7 +95,7 @@ export const useClientStore = create<ClientState>()(
             ...s.pastBookings,
             {
               ...s.upcomingBookings.find((b) => b.id === id)!,
-              status: "cancelled",
+              status: 'cancelled',
             },
           ],
         })),
@@ -179,16 +112,16 @@ export const useClientStore = create<ClientState>()(
           pastBookings: getMockPastBookings(),
           availableServices: getMockAvailableServices(),
           bookingHistory: getMockBookingHistory(),
-        })
+        });
       },
     }),
     {
-      name: "client-storage",
+      name: 'client-storage',
       partialize: (state) => ({
         profile: state.profile,
         upcomingBookings: state.upcomingBookings,
         pastBookings: state.pastBookings,
       }),
-    },
-  ),
-)
+    }
+  )
+);

--- a/scripts/create-bookings-view.sql
+++ b/scripts/create-bookings-view.sql
@@ -1,0 +1,72 @@
+-- =====================================================
+-- CREATE VIEW: bookings_with_details
+-- Vista para obtener bookings con información relacionada
+-- =====================================================
+
+CREATE OR REPLACE VIEW public.bookings_with_details WITH (security_invoker=on) AS
+SELECT 
+    b.id,
+    b.client_id,
+    b.professional_id,
+    b.service_id,
+    b.workplace_id,
+    b.company_id,
+    b.booking_date,
+    b.booking_time,
+    b.duration,
+    b.price,
+    b.status,
+    b.notes,
+    b.instructions,
+    b.description,
+    b.cancellation_reason,
+    b.payment_status,
+    b.payment_method,
+    b.created_at,
+    b.updated_at,
+    
+    -- Información del servicio
+    s.name as service_name,
+    s.category as service_category,
+    
+    -- Información del profesional
+    p.name as professional_name,
+    p.title as professional_title,
+    p.specialties as professional_specialty,
+    p.phone as professional_phone,
+    p.email as professional_email,
+    
+    -- Información del lugar de trabajo
+    w.name as workplace_name,
+    w.address as workplace_address,
+    w.phone as workplace_phone,
+    w.email as workplace_email,
+    
+    -- Información de la empresa
+    c.name as company_name,
+    
+    -- Información del cliente
+    cl.name as client_name,
+    cl.email as client_email,
+    cl.phone as client_phone,
+    
+    -- Campos calculados para la UI
+    CONCAT('$', b.price::text) as formatted_price,
+    CONCAT(b.duration::text, ' min') as formatted_duration,
+    TO_CHAR(b.booking_date, 'YYYY-MM-DD') as formatted_date,
+    TO_CHAR(b.booking_time, 'HH24:MI') as formatted_time,
+    
+    -- Rating desde reviews (si existe)
+    r.rating,
+    r.comment as review_comment
+
+FROM public.bookings b
+LEFT JOIN public.services s ON b.service_id = s.id
+LEFT JOIN public.professionals p ON b.professional_id = p.id
+LEFT JOIN public.workplaces w ON b.workplace_id = w.id
+LEFT JOIN public.companies c ON b.company_id = c.id
+LEFT JOIN public.clients cl ON b.client_id = cl.id
+LEFT JOIN public.reviews r ON b.id = r.booking_id;
+
+-- Grant permissions
+GRANT SELECT ON public.bookings_with_details TO authenticated;

--- a/scripts/create-complete-database-schema.sql
+++ b/scripts/create-complete-database-schema.sql
@@ -111,6 +111,15 @@ CREATE TABLE IF NOT EXISTS public.services (
     duration INTEGER NOT NULL, -- in minutes
     price DECIMAL(10,2) NOT NULL,
     category TEXT,
+    schedule JSONB DEFAULT '{}', -- Service availability schedule
+    tags TEXT[] DEFAULT '{}', -- Service tags for filtering
+    requirements TEXT, -- Special requirements or preparations needed
+    preparation_time INTEGER DEFAULT 0, -- Preparation time in minutes
+    cleanup_time INTEGER DEFAULT 0, -- Cleanup time in minutes
+    max_bookings_per_day INTEGER DEFAULT 20, -- Maximum bookings allowed per day
+    booking_window_days INTEGER DEFAULT 30, -- Days in advance for booking
+    image_url TEXT, -- Service image URL
+    color TEXT DEFAULT '#3B82F6', -- Color for visual identification
     is_active BOOLEAN DEFAULT true,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL
@@ -144,9 +153,14 @@ CREATE TABLE IF NOT EXISTS public.clients (
     phone TEXT,
     date_of_birth DATE,
     address TEXT,
-    emergency_contact TEXT,
-    emergency_phone TEXT,
-    medical_notes TEXT,
+    emergency_contact JSONB, -- {name: string, phone: string, relationship: string}
+    medical_history TEXT[] DEFAULT '{}',
+    allergies TEXT[] DEFAULT '{}',
+    current_medications TEXT[] DEFAULT '{}',
+    insurance_provider TEXT,
+    insurance_number TEXT,
+    preferred_language TEXT DEFAULT 'Español',
+    communication_preferences JSONB DEFAULT '{"email": true, "sms": true, "phone": false}',
     created_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL
 );
@@ -167,6 +181,8 @@ CREATE TABLE IF NOT EXISTS public.bookings (
     price DECIMAL(10,2) NOT NULL,
     status TEXT CHECK (status IN ('pending', 'confirmed', 'completed', 'cancelled', 'no_show')) DEFAULT 'pending',
     notes TEXT,
+    instructions TEXT, -- Special instructions for the booking
+    description TEXT, -- Description of the service/reason for visit
     cancellation_reason TEXT,
     payment_status TEXT CHECK (payment_status IN ('pending', 'paid', 'refunded')) DEFAULT 'pending',
     payment_method TEXT,
@@ -228,6 +244,10 @@ CREATE INDEX IF NOT EXISTS idx_professionals_company_id ON public.professionals(
 CREATE INDEX IF NOT EXISTS idx_workplaces_company_id ON public.workplaces(company_id);
 CREATE INDEX IF NOT EXISTS idx_services_professional_id ON public.services(professional_id);
 CREATE INDEX IF NOT EXISTS idx_services_workplace_id ON public.services(workplace_id);
+CREATE INDEX IF NOT EXISTS idx_services_category ON public.services(category);
+CREATE INDEX IF NOT EXISTS idx_services_is_active ON public.services(is_active);
+CREATE INDEX IF NOT EXISTS idx_services_tags ON public.services USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_services_schedule ON public.services USING GIN(schedule);
 CREATE INDEX IF NOT EXISTS idx_clients_user_id ON public.clients(user_id);
 CREATE INDEX IF NOT EXISTS idx_bookings_client_id ON public.bookings(client_id);
 CREATE INDEX IF NOT EXISTS idx_bookings_professional_id ON public.bookings(professional_id);

--- a/scripts/create-services-view.sql
+++ b/scripts/create-services-view.sql
@@ -1,0 +1,67 @@
+-- =====================================================
+-- CREATE SERVICES VIEW WITH RELATED DATA
+-- Vista que expone servicios con información de profesional y lugar
+-- =====================================================
+
+CREATE OR REPLACE VIEW public.services_with_details AS
+SELECT 
+    s.id,
+    s.professional_id,
+    s.workplace_id,
+    s.name,
+    s.description,
+    s.duration,
+    s.price,
+    s.category,
+    s.schedule,
+    s.tags,
+    s.requirements,
+    s.preparation_time,
+    s.cleanup_time,
+    s.max_bookings_per_day,
+    s.booking_window_days,
+    s.image_url,
+    s.color,
+    s.is_active,
+    s.created_at,
+    s.updated_at,
+    
+    -- Professional details
+    p.name as professional_name,
+    p.title as professional_title,
+    p.email as professional_email,
+    p.phone as professional_phone,
+    p.specialties as professional_specialties,
+    p.rating as professional_rating,
+    p.experience as professional_experience,
+    p.avatar_url as professional_avatar,
+    
+    -- Workplace details
+    w.name as workplace_name,
+    w.address as workplace_address,
+    w.description as workplace_description,
+    w.phone as workplace_phone,
+    w.email as workplace_email,
+    
+    -- Company details (through workplace)
+    c.id as company_id,
+    c.name as company_name
+    
+FROM public.services s
+INNER JOIN public.professionals p ON s.professional_id = p.id
+INNER JOIN public.workplaces w ON s.workplace_id = w.id
+LEFT JOIN public.companies c ON w.company_id = c.id
+WHERE s.is_active = true;
+
+-- Grant permissions
+GRANT SELECT ON public.services_with_details TO authenticated;
+
+-- Add RLS policy for the view
+DROP POLICY IF EXISTS "services_with_details_select_policy" ON public.services_with_details;
+-- Note: Views inherit RLS from underlying tables
+
+-- Create indexes for performance (if not already exists)
+CREATE INDEX IF NOT EXISTS idx_services_active_professional ON public.services(professional_id, is_active);
+CREATE INDEX IF NOT EXISTS idx_services_active_workplace ON public.services(workplace_id, is_active);
+
+COMMENT ON VIEW public.services_with_details IS 'Vista que combina servicios con información de profesional, lugar de trabajo y empresa para consultas optimizadas';

--- a/scripts/migrate-bookings-table.sql
+++ b/scripts/migrate-bookings-table.sql
@@ -1,0 +1,18 @@
+-- =====================================================
+-- MIGRATION: Update bookings table to match UI requirements
+-- =====================================================
+
+-- Add new columns to bookings table
+ALTER TABLE public.bookings 
+ADD COLUMN IF NOT EXISTS instructions TEXT;
+
+ALTER TABLE public.bookings 
+ADD COLUMN IF NOT EXISTS description TEXT;
+
+-- Add comments for documentation
+COMMENT ON COLUMN public.bookings.instructions IS 'Special instructions for the booking (e.g., "Bring previous studies", "Wear comfortable clothes")';
+COMMENT ON COLUMN public.bookings.description IS 'Description of the service/reason for visit';
+
+-- Update indexes if needed
+CREATE INDEX IF NOT EXISTS idx_bookings_instructions ON public.bookings(instructions) WHERE instructions IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_bookings_description ON public.bookings(description) WHERE description IS NOT NULL;

--- a/scripts/migrate-clients-table.sql
+++ b/scripts/migrate-clients-table.sql
@@ -1,0 +1,59 @@
+-- =====================================================
+-- MIGRATION: Update clients table to match UI requirements
+-- =====================================================
+
+-- Add new columns to clients table
+ALTER TABLE public.clients 
+ADD COLUMN IF NOT EXISTS medical_history TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+ALTER TABLE public.clients 
+ADD COLUMN IF NOT EXISTS allergies TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+ALTER TABLE public.clients 
+ADD COLUMN IF NOT EXISTS current_medications TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+ALTER TABLE public.clients 
+ADD COLUMN IF NOT EXISTS insurance_provider TEXT;
+
+ALTER TABLE public.clients 
+ADD COLUMN IF NOT EXISTS insurance_number TEXT;
+
+ALTER TABLE public.clients 
+ADD COLUMN IF NOT EXISTS preferred_language TEXT DEFAULT 'Español';
+
+ALTER TABLE public.clients 
+ADD COLUMN IF NOT EXISTS communication_preferences JSONB DEFAULT '{"email": true, "sms": true, "phone": false}';
+
+-- Update emergency_contact structure
+-- First, add the new JSONB column
+ALTER TABLE public.clients ADD COLUMN IF NOT EXISTS emergency_contact_new JSONB;
+
+-- Migrate existing data (if any exists)
+UPDATE public.clients 
+SET emergency_contact_new = jsonb_build_object(
+    'name', '',
+    'phone', '',
+    'relationship', ''
+)
+WHERE emergency_contact IS NOT NULL;
+
+-- Drop old columns
+ALTER TABLE public.clients DROP COLUMN IF EXISTS emergency_contact;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS emergency_phone;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS medical_notes;
+
+-- Rename new column
+ALTER TABLE public.clients RENAME COLUMN emergency_contact_new TO emergency_contact;
+
+-- Update the trigger for the clients table (if not already exists)
+DROP TRIGGER IF EXISTS handle_clients_updated_at ON public.clients;
+CREATE TRIGGER handle_clients_updated_at
+    BEFORE UPDATE ON public.clients
+    FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- Add comments for documentation
+COMMENT ON COLUMN public.clients.emergency_contact IS 'JSON object containing emergency contact information: {name: string, phone: string, relationship: string}';
+COMMENT ON COLUMN public.clients.medical_history IS 'Array of medical conditions/history';
+COMMENT ON COLUMN public.clients.allergies IS 'Array of known allergies';
+COMMENT ON COLUMN public.clients.current_medications IS 'Array of current medications';
+COMMENT ON COLUMN public.clients.communication_preferences IS 'JSON object for communication preferences: {email: boolean, sms: boolean, phone: boolean}';

--- a/scripts/migrate-services-table.sql
+++ b/scripts/migrate-services-table.sql
@@ -1,0 +1,72 @@
+-- =====================================================
+-- MIGRATE SERVICES TABLE
+-- Agregar campos faltantes para alinear con la UI
+-- =====================================================
+
+-- Agregar campos faltantes a la tabla services
+ALTER TABLE public.services ADD COLUMN IF NOT EXISTS schedule JSONB DEFAULT '{}';
+ALTER TABLE public.services ADD COLUMN IF NOT EXISTS tags TEXT[] DEFAULT '{}';
+ALTER TABLE public.services ADD COLUMN IF NOT EXISTS requirements TEXT;
+ALTER TABLE public.services ADD COLUMN IF NOT EXISTS preparation_time INTEGER DEFAULT 0; -- in minutes
+ALTER TABLE public.services ADD COLUMN IF NOT EXISTS cleanup_time INTEGER DEFAULT 0; -- in minutes
+ALTER TABLE public.services ADD COLUMN IF NOT EXISTS max_bookings_per_day INTEGER DEFAULT 20;
+ALTER TABLE public.services ADD COLUMN IF NOT EXISTS booking_window_days INTEGER DEFAULT 30;
+ALTER TABLE public.services ADD COLUMN IF NOT EXISTS image_url TEXT;
+ALTER TABLE public.services ADD COLUMN IF NOT EXISTS color TEXT DEFAULT '#3B82F6';
+
+-- Crear índices para los nuevos campos
+CREATE INDEX IF NOT EXISTS idx_services_tags ON public.services USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_services_schedule ON public.services USING GIN(schedule);
+CREATE INDEX IF NOT EXISTS idx_services_category ON public.services(category);
+CREATE INDEX IF NOT EXISTS idx_services_is_active ON public.services(is_active);
+
+-- Migrar datos existentes de service_schedules a services.schedule si existen
+-- (Solo ejecutar si la tabla service_schedules tiene datos)
+DO $$
+DECLARE
+    service_record RECORD;
+    schedule_json JSONB := '{}';
+    day_schedule RECORD;
+BEGIN
+    -- Para cada servicio existente
+    FOR service_record IN SELECT id FROM public.services LOOP
+        schedule_json := '{}';
+        
+        -- Construir el objeto JSON de horarios
+        FOR day_schedule IN 
+            SELECT day_of_week, is_available, start_time, end_time, break_start, break_end
+            FROM public.service_schedules 
+            WHERE service_id = service_record.id
+        LOOP
+            schedule_json := schedule_json || jsonb_build_object(
+                day_schedule.day_of_week,
+                jsonb_build_object(
+                    'isAvailable', day_schedule.is_available,
+                    'startTime', COALESCE(day_schedule.start_time::text, ''),
+                    'endTime', COALESCE(day_schedule.end_time::text, ''),
+                    'breakStart', COALESCE(day_schedule.break_start::text, ''),
+                    'breakEnd', COALESCE(day_schedule.break_end::text, '')
+                )
+            );
+        END LOOP;
+        
+        -- Actualizar el servicio con el horario JSON
+        UPDATE public.services 
+        SET schedule = schedule_json 
+        WHERE id = service_record.id;
+    END LOOP;
+END $$;
+
+-- Comentar para mantener la tabla service_schedules por compatibilidad
+-- pero la UI usará el campo schedule JSONB
+-- DROP TABLE IF EXISTS public.service_schedules;
+
+COMMENT ON COLUMN public.services.schedule IS 'Horarios de disponibilidad del servicio en formato JSON: {day: {isAvailable, startTime, endTime, breakStart, breakEnd}}';
+COMMENT ON COLUMN public.services.tags IS 'Etiquetas o características del servicio para filtrado y búsqueda';
+COMMENT ON COLUMN public.services.requirements IS 'Requisitos especiales o preparativos necesarios para el servicio';
+COMMENT ON COLUMN public.services.preparation_time IS 'Tiempo de preparación previo requerido en minutos';
+COMMENT ON COLUMN public.services.cleanup_time IS 'Tiempo de limpieza posterior requerido en minutos';
+COMMENT ON COLUMN public.services.max_bookings_per_day IS 'Número máximo de reservas permitidas por día';
+COMMENT ON COLUMN public.services.booking_window_days IS 'Días de anticipación máxima para hacer reservas';
+COMMENT ON COLUMN public.services.image_url IS 'URL de la imagen representativa del servicio';
+COMMENT ON COLUMN public.services.color IS 'Color hexadecimal para identificación visual en calendarios';

--- a/scripts/seed-services-data.sql
+++ b/scripts/seed-services-data.sql
@@ -1,0 +1,179 @@
+-- =====================================================
+-- SEED DATA FOR SERVICES WITH NEW STRUCTURE
+-- Datos de ejemplo para servicios con la nueva estructura
+-- =====================================================
+
+-- Insertar servicios de ejemplo con horarios y campos nuevos
+-- Nota: Asume que ya existen professionals y workplaces con IDs específicos
+
+INSERT INTO public.services (
+    id,
+    professional_id,
+    workplace_id,
+    name,
+    description,
+    duration,
+    price,
+    category,
+    schedule,
+    tags,
+    requirements,
+    preparation_time,
+    cleanup_time,
+    max_bookings_per_day,
+    booking_window_days,
+    image_url,
+    color,
+    is_active
+) VALUES
+-- Servicio 1: Consulta Médica General
+(
+    '550e8400-e29b-41d4-a716-446655440001',
+    '550e8400-e29b-41d4-a716-446655440101', -- professional_id (cambiar por ID real)
+    '550e8400-e29b-41d4-a716-446655440201', -- workplace_id (cambiar por ID real)
+    'Consulta Médica General',
+    'Consulta médica integral con revisión completa del estado de salud del paciente',
+    30,
+    150.00,
+    'Medicina General',
+    '{
+        "monday": {"isAvailable": true, "startTime": "08:00", "endTime": "17:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "tuesday": {"isAvailable": true, "startTime": "08:00", "endTime": "17:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "wednesday": {"isAvailable": true, "startTime": "08:00", "endTime": "17:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "thursday": {"isAvailable": true, "startTime": "08:00", "endTime": "17:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "friday": {"isAvailable": true, "startTime": "08:00", "endTime": "17:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "saturday": {"isAvailable": true, "startTime": "08:00", "endTime": "12:00", "breakStart": "", "breakEnd": ""},
+        "sunday": {"isAvailable": false, "startTime": "", "endTime": "", "breakStart": "", "breakEnd": ""}
+    }',
+    ARRAY['consulta', 'medicina general', 'diagnóstico', 'prevención'],
+    'Traer carnet de obra social o prepaga. Ayuno de 8 horas si requiere análisis de sangre.',
+    5,
+    5,
+    12,
+    30,
+    '/images/services/consulta-general.jpg',
+    '#3B82F6',
+    true
+),
+-- Servicio 2: Chequeo Médico Completo
+(
+    '550e8400-e29b-41d4-a716-446655440002',
+    '550e8400-e29b-41d4-a716-446655440101', -- mismo professional
+    '550e8400-e29b-41d4-a716-446655440201', -- mismo workplace
+    'Chequeo Médico Completo',
+    'Evaluación médica exhaustiva con análisis de laboratorio y estudios complementarios incluidos',
+    60,
+    300.00,
+    'Medicina General',
+    '{
+        "monday": {"isAvailable": true, "startTime": "09:00", "endTime": "16:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "tuesday": {"isAvailable": true, "startTime": "09:00", "endTime": "16:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "wednesday": {"isAvailable": false, "startTime": "", "endTime": "", "breakStart": "", "breakEnd": ""},
+        "thursday": {"isAvailable": true, "startTime": "09:00", "endTime": "16:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "friday": {"isAvailable": true, "startTime": "09:00", "endTime": "16:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "saturday": {"isAvailable": false, "startTime": "", "endTime": "", "breakStart": "", "breakEnd": ""},
+        "sunday": {"isAvailable": false, "startTime": "", "endTime": "", "breakStart": "", "breakEnd": ""}
+    }',
+    ARRAY['chequeo', 'examen completo', 'laboratorio', 'prevención', 'análisis'],
+    'Ayuno de 12 horas. Traer estudios previos si los tiene. Ropa cómoda.',
+    10,
+    10,
+    6,
+    45,
+    '/images/services/chequeo-completo.jpg',
+    '#10B981',
+    true
+),
+-- Servicio 3: Terapia Física
+(
+    '550e8400-e29b-41d4-a716-446655440003',
+    '550e8400-e29b-41d4-a716-446655440102', -- different professional
+    '550e8400-e29b-41d4-a716-446655440202', -- different workplace
+    'Terapia Física',
+    'Sesión de fisioterapia para rehabilitación, recuperación de lesiones y mejora del movimiento',
+    60,
+    200.00,
+    'Fisioterapia',
+    '{
+        "monday": {"isAvailable": true, "startTime": "07:00", "endTime": "18:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "tuesday": {"isAvailable": true, "startTime": "07:00", "endTime": "18:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "wednesday": {"isAvailable": true, "startTime": "07:00", "endTime": "18:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "thursday": {"isAvailable": true, "startTime": "07:00", "endTime": "18:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "friday": {"isAvailable": true, "startTime": "07:00", "endTime": "18:00", "breakStart": "12:00", "breakEnd": "13:00"},
+        "saturday": {"isAvailable": true, "startTime": "08:00", "endTime": "14:00", "breakStart": "", "breakEnd": ""},
+        "sunday": {"isAvailable": false, "startTime": "", "endTime": "", "breakStart": "", "breakEnd": ""}
+    }',
+    ARRAY['fisioterapia', 'rehabilitación', 'terapia física', 'lesiones', 'movilidad'],
+    'Traer ropa deportiva cómoda y toalla. Comunicar cualquier dolor o molestia antes de comenzar.',
+    10,
+    15,
+    8,
+    21,
+    '/images/services/terapia-fisica.jpg',
+    '#F59E0B',
+    true
+),
+-- Servicio 4: Consulta Nutricional
+(
+    '550e8400-e29b-41d4-a716-446655440004',
+    '550e8400-e29b-41d4-a716-446655440103', -- different professional (nutricionista)
+    '550e8400-e29b-41d4-a716-446655440201', -- workplace 1
+    'Consulta Nutricional',
+    'Evaluación nutricional completa con plan alimentario personalizado y seguimiento',
+    45,
+    140.00,
+    'Nutrición',
+    '{
+        "monday": {"isAvailable": true, "startTime": "14:00", "endTime": "18:00", "breakStart": "", "breakEnd": ""},
+        "tuesday": {"isAvailable": true, "startTime": "14:00", "endTime": "18:00", "breakStart": "", "breakEnd": ""},
+        "wednesday": {"isAvailable": true, "startTime": "14:00", "endTime": "18:00", "breakStart": "", "breakEnd": ""},
+        "thursday": {"isAvailable": true, "startTime": "14:00", "endTime": "18:00", "breakStart": "", "breakEnd": ""},
+        "friday": {"isAvailable": true, "startTime": "14:00", "endTime": "18:00", "breakStart": "", "breakEnd": ""},
+        "saturday": {"isAvailable": true, "startTime": "09:00", "endTime": "13:00", "breakStart": "", "breakEnd": ""},
+        "sunday": {"isAvailable": false, "startTime": "", "endTime": "", "breakStart": "", "breakEnd": ""}
+    }',
+    ARRAY['nutrición', 'alimentación', 'dieta', 'peso', 'salud nutricional'],
+    'Traer estudios de laboratorio recientes si los tiene. Registro de comidas de 3 días.',
+    5,
+    5,
+    10,
+    30,
+    '/images/services/consulta-nutricional.jpg',
+    '#8B5CF6',
+    true
+),
+-- Servicio 5: Consulta Dermatológica
+(
+    '550e8400-e29b-41d4-a716-446655440005',
+    '550e8400-e29b-41d4-a716-446655440104', -- dermatólogo
+    '550e8400-e29b-41d4-a716-446655440203', -- workplace 3
+    'Consulta Dermatológica',
+    'Evaluación especializada de problemas de la piel, diagnóstico y tratamiento dermatológico',
+    30,
+    180.00,
+    'Dermatología',
+    '{
+        "monday": {"isAvailable": true, "startTime": "09:00", "endTime": "16:00", "breakStart": "13:00", "breakEnd": "14:00"},
+        "tuesday": {"isAvailable": true, "startTime": "09:00", "endTime": "16:00", "breakStart": "13:00", "breakEnd": "14:00"},
+        "wednesday": {"isAvailable": true, "startTime": "09:00", "endTime": "16:00", "breakStart": "13:00", "breakEnd": "14:00"},
+        "thursday": {"isAvailable": true, "startTime": "09:00", "endTime": "16:00", "breakStart": "13:00", "breakEnd": "14:00"},
+        "friday": {"isAvailable": true, "startTime": "09:00", "endTime": "16:00", "breakStart": "13:00", "breakEnd": "14:00"},
+        "saturday": {"isAvailable": false, "startTime": "", "endTime": "", "breakStart": "", "breakEnd": ""},
+        "sunday": {"isAvailable": false, "startTime": "", "endTime": "", "breakStart": "", "breakEnd": ""}
+    }',
+    ARRAY['dermatología', 'piel', 'lunares', 'acné', 'diagnóstico dermatológico'],
+    'Evitar cremas o maquillaje en la zona a examinar. Traer lista de medicamentos actuales.',
+    5,
+    5,
+    15,
+    60,
+    '/images/services/consulta-dermatologica.jpg',
+    '#EF4444',
+    true
+);
+
+-- Comentarios sobre el seed data
+COMMENT ON TABLE public.services IS 'Tabla de servicios con campos enriquecidos para gestión completa';
+
+-- Verificar que los datos se insertaron correctamente
+-- SELECT name, category, tags, schedule FROM public.services WHERE id IN ('550e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440002');

--- a/types/booking.ts
+++ b/types/booking.ts
@@ -1,57 +1,133 @@
+import type { Database } from '@/lib/database.types';
+
+// Tipo base de booking desde la base de datos
+export type BookingRow = Database['public']['Tables']['bookings']['Row'];
+export type BookingInsert = Database['public']['Tables']['bookings']['Insert'];
+export type BookingUpdate = Database['public']['Tables']['bookings']['Update'];
+
+// Tipo para booking con información relacionada (para JOINs)
+export interface BookingWithDetails extends BookingRow {
+  // Información del servicio
+  service_name: string;
+  service_category: string;
+
+  // Información del profesional
+  professional_name: string;
+  professional_title: string | null;
+  professional_specialty: string[];
+  professional_phone: string | null;
+  professional_email: string;
+
+  // Información del lugar de trabajo
+  workplace_name: string;
+  workplace_address: string;
+  workplace_phone: string | null;
+  workplace_email: string | null;
+
+  // Información de la empresa
+  company_name: string | null;
+
+  // Información del cliente
+  client_name: string;
+  client_email: string;
+  client_phone: string | null;
+}
+
+// Tipo para la UI del cliente (simplificado)
+export interface ClientBookingView {
+  id: string;
+  service: string;
+  professional: string;
+  date: string;
+  time: string;
+  location: string;
+  price: string;
+  duration: string;
+  status: 'pending' | 'confirmed' | 'completed' | 'cancelled';
+  specialty: string;
+  phone: string | null;
+  instructions: string | null;
+  description: string | null;
+  notes: string | null;
+  rating?: number | null; // Viene de la tabla reviews
+}
+
+// Tipo para el historial de reservas
+export interface BookingHistoryItem extends ClientBookingView {
+  rating: number | null;
+  review_comment: string | null;
+  completion_date: string | null;
+}
+
+// Estados de reserva
+export type BookingStatus =
+  | 'pending'
+  | 'confirmed'
+  | 'completed'
+  | 'cancelled'
+  | 'no_show';
+export type PaymentStatus = 'pending' | 'paid' | 'refunded';
+
+// Tipos para el proceso de reserva (legacy - mantener compatibilidad)
 export interface BookingService {
-  id: string
-  name: string
-  description: string
-  duration: number // En minutos
-  professionals: string[]
-  price: number
-  category: string
-  locations: string[]
+  id: string;
+  name: string;
+  description: string;
+  duration: number; // En minutos
+  professionals: string[];
+  price: number;
+  category: string;
+  locations: string[];
 }
 
 export interface BookingLocation {
-  id: string
-  name: string
-  address: string
+  id: string;
+  name: string;
+  address: string;
 }
 
 export interface BookingProfessional {
-  id: string
-  name: string
-  title: string
-  specialties: string[]
-  rating: number
-  experience: string
-  locations: string[]
+  id: string;
+  name: string;
+  title: string;
+  specialties: string[];
+  rating: number;
+  experience: string;
+  locations: string[];
   services?: Array<{
-    id: string
-    name: string
-    schedule: ServiceSchedule
-  }>
+    id: string;
+    name: string;
+    schedule: ServiceSchedule;
+  }>;
 }
 
 export interface ServiceSchedule {
   [key: string]: {
-    isAvailable: boolean
-    startTime: string
-    endTime: string
-    breakStart?: string
-    breakEnd?: string
-  }
+    isAvailable: boolean;
+    startTime: string;
+    endTime: string;
+    breakStart?: string;
+    breakEnd?: string;
+  };
 }
 
 export interface BookingData {
-  service: BookingService | null
-  location: BookingLocation | null
-  professional: BookingProfessional | null
-  date: string
-  time: string
+  service: BookingService | null;
+  location: BookingLocation | null;
+  professional: BookingProfessional | null;
+  date: string;
+  time: string;
 }
 
-export type BookingStep = "service" | "location" | "professional" | "datetime" | "confirmation"
+export type BookingStep =
+  | 'service'
+  | 'location'
+  | 'professional'
+  | 'datetime'
+  | 'confirmation';
 
 export interface BookingStepProps {
-  data: BookingData
-  onNext: (data: Partial<BookingData>) => void
-  onBack: () => void
+  data: BookingData;
+  onNext: (data: Partial<BookingData>) => void;
+  onBack: () => void;
 }

--- a/types/client.ts
+++ b/types/client.ts
@@ -1,88 +1,146 @@
-import type { Profile } from "./auth"
+import type { Profile } from './auth';
+import type { Database } from '@/lib/database.types';
 
+// Tipo base desde la base de datos
+type ClientDBRow = Database['public']['Tables']['clients']['Row'];
+
+// Interfaz extendida para el cliente que combina Profile y datos específicos del cliente
 export interface ClientProfile extends Profile {
-  date_of_birth?: string
-  address?: string
+  // Campos específicos del cliente desde la base de datos
+  date_of_birth?: string | null;
+  address?: string | null;
   emergency_contact?: {
-    name: string
-    phone: string
-    relationship: string
-  }
-  medical_history?: string[]
-  allergies?: string[]
-  current_medications?: string[]
-  insurance_provider?: string
-  insurance_number?: string
-  preferred_language?: string
+    name: string;
+    phone: string;
+    relationship: string;
+  } | null;
+  medical_history?: string[] | null;
+  allergies?: string[] | null;
+  current_medications?: string[] | null;
+  insurance_provider?: string | null;
+  insurance_number?: string | null;
+  preferred_language?: string | null;
   communication_preferences?: {
-    email: boolean
-    sms: boolean
-    phone: boolean
-  }
+    email: boolean;
+    sms: boolean;
+    phone: boolean;
+  } | null;
+
+  // Campos de compatibilidad con la UI existente
+  name?: string; // Alias para full_name
 }
 
 export interface ClientBooking {
-  id: string
-  date: string
-  professional: string
-  clinic: string
-  status: "confirmed" | "pending" | "cancelled"
+  id: string;
+  date: string;
+  time?: string;
+  professional: string;
+  clinic: string;
+  status: 'confirmed' | 'pending' | 'cancelled' | 'completed';
+  // Campos adicionales para la UI completa
+  service?: string;
+  location?: string;
+  price?: string;
+  duration?: string;
+  specialty?: string;
+  phone?: string;
+  instructions?: string;
+  description?: string;
+  rating?: number | null;
+  notes?: string;
+}
+
+// Tipo extendido basado en la base de datos con JOINs
+export interface BookingWithDetails {
+  id: string;
+  client_id: string;
+  professional_id: string;
+  service_id: string;
+  workplace_id: string;
+  company_id: string | null;
+  booking_date: string;
+  booking_time: string;
+  duration: number;
+  price: number;
+  status: 'pending' | 'confirmed' | 'completed' | 'cancelled' | 'no_show';
+  notes: string | null;
+  instructions: string | null;
+  description: string | null;
+  cancellation_reason: string | null;
+  payment_status: 'pending' | 'paid' | 'refunded';
+  payment_method: string | null;
+  created_at: string;
+  updated_at: string;
+  // Campos de JOIN
+  service_name: string;
+  professional_name: string;
+  professional_specialty: string;
+  professional_phone: string | null;
+  workplace_name: string;
+  workplace_address: string;
+  workplace_phone: string | null;
+  company_name: string | null;
+  // Campos calculados para la UI
+  formatted_price: string;
+  formatted_duration: string;
+  formatted_date: string;
+  formatted_time: string;
 }
 
 export interface AvailableService {
-  id: string
-  name: string
-  description: string
-  category: string
-  duration: number
-  price: number
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  duration: number;
+  price: number;
   professional: {
-    id: string
-    name: string
-    specialty: string
-    rating: number
-    avatar_url?: string
-  }
+    id: string;
+    name: string;
+    specialty: string;
+    rating: number;
+    avatar_url?: string;
+  };
   location: {
-    id: string
-    name: string
-    address: string
-    phone: string
-  }
+    id: string;
+    name: string;
+    address: string;
+    phone: string;
+  };
   available_slots: Array<{
-    date: string
-    times: string[]
-  }>
-  is_popular: boolean
-  tags: string[]
+    date: string;
+    times: string[];
+  }>;
+  is_popular: boolean;
+  tags: string[];
 }
 
 export interface BookingHistory {
-  total_bookings: number
-  completed_bookings: number
-  cancelled_bookings: number
-  no_show_bookings: number
-  total_spent: number
-  average_rating_given: number
-  favorite_professional?: string
-  most_booked_service?: string
-  first_booking_date?: string
-  last_booking_date?: string
+  total_bookings: number;
+  completed_bookings: number;
+  cancelled_bookings: number;
+  no_show_bookings: number;
+  total_spent: number;
+  average_rating_given: number;
+  favorite_professional?: string;
+  most_booked_service?: string;
+  first_booking_date?: string;
+  last_booking_date?: string;
 }
 
-export type ClientTab = "dashboard" | "bookings" | "history" | "profile"
+export type ClientTab = 'dashboard' | 'bookings' | 'history' | 'profile';
 
 export interface ClientSlice {
-  activeTab: ClientTab
-  profile: ClientProfile | null
-  upcomingBookings: ClientBooking[]
-  pastBookings: ClientBooking[]
-  availableServices: AvailableService[]
-  bookingHistory: BookingHistory
-  isBookingModalOpen: boolean
-  selectedService: AvailableService | null
-  setActiveTab: (tab: ClientTab) => void
-  setProfile: (profile: ClientProfile) => void
-  addBooking: (booking: ClientBooking) => void
-  loadData: () => void
+  activeTab: ClientTab;
+  profile: ClientProfile | null;
+  upcomingBookings: ClientBooking[];
+  pastBookings: ClientBooking[];
+  availableServices: AvailableService[];
+  bookingHistory: BookingHistory;
+  isBookingModalOpen: boolean;
+  selectedService: AvailableService | null;
+  setActiveTab: (tab: ClientTab) => void;
+  setProfile: (profile: ClientProfile) => void;
+  addBooking: (booking: ClientBooking) => void;
+  loadData: () => void;
 }

--- a/types/professional.ts
+++ b/types/professional.ts
@@ -1,90 +1,128 @@
+import type { Database } from '@/lib/database.types';
+import type { ServiceSchedule } from '@/types/booking';
+
+// Re-export database types with enhanced UI types
+export type Service = Database['public']['Tables']['services']['Row'] & {
+  schedule?: ServiceSchedule;
+  workplaceId?: string; // For UI compatibility
+  isActive?: boolean; // For UI compatibility
+};
+
+export type Workplace = Database['public']['Tables']['workplaces']['Row'];
+
+// Add missing types for compatibility
+export type Professional = Database['public']['Tables']['professionals']['Row'];
+export type Client = Database['public']['Tables']['clients']['Row'];
+
+// Booking type for Professional UI (legacy compatibility)
+export interface Booking {
+  id: string;
+  date: string;
+  time: string;
+  service: string;
+  client: string;
+  status: 'pending' | 'confirmed' | 'completed' | 'cancelled';
+  location: string;
+  duration: string;
+  price: string;
+  workplaceId?: string;
+}
+
+// Dashboard stats interface
+export interface DashboardStats {
+  todayBookings: number;
+  pendingBookings: number;
+  weeklyBookings: number;
+  monthlyRevenue: number;
+}
+
 export interface ProfessionalService {
-  id: string
-  name: string
-  description: string
-  duration: number
-  price: number
-  category: string
-  is_active: boolean
-  created_at: string
+  id: string;
+  name: string;
+  description: string;
+  duration: number;
+  price: number;
+  category: string;
+  is_active: boolean;
+  created_at: string;
 }
 
 export interface ProfessionalBooking {
-  id: string
-  client_name: string
-  client_email: string
-  client_phone: string
-  service_name: string
-  date: string
-  time: string
-  status: "pending" | "confirmed" | "completed" | "cancelled"
-  notes?: string
-  location_name: string
-  created_at: string
+  id: string;
+  client_name: string;
+  client_email: string;
+  client_phone: string;
+  service_name: string;
+  date: string;
+  time: string;
+  status: 'pending' | 'confirmed' | 'completed' | 'cancelled';
+  notes?: string;
+  location_name: string;
+  created_at: string;
 }
 
 export interface ProfessionalClient {
-  id: string
-  name: string
-  email: string
-  phone: string
-  last_visit: string
-  total_visits: number
-  total_spent: number
-  notes?: string
-  created_at: string
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  last_visit: string;
+  total_visits: number;
+  total_spent: number;
+  notes?: string;
+  created_at: string;
 }
 
 export interface ProfessionalLocation {
-  id: string
-  name: string
-  address: string
-  city: string
-  phone: string
-  is_active: boolean
-  created_at: string
+  id: string;
+  name: string;
+  address: string;
+  city: string;
+  phone: string;
+  is_active: boolean;
+  created_at: string;
 }
 
 export interface Clinic {
-  id: string
-  name: string
-  address: string
-  phone: string
-  email: string
+  id: string;
+  name: string;
+  address: string;
+  phone: string;
+  email: string;
 }
 
 export interface ProfessionalStats {
-  totalBookings: number
-  completedBookings: number
-  pendingBookings: number
-  totalRevenue: number
-  monthlyRevenue: number
-  totalClients: number
-  newClientsThisMonth: number
-  averageRating: number
+  totalBookings: number;
+  completedBookings: number;
+  pendingBookings: number;
+  totalRevenue: number;
+  monthlyRevenue: number;
+  totalClients: number;
+  newClientsThisMonth: number;
+  averageRating: number;
 }
 
 export type ProfessionalTab =
-  | "dashboard"
-  | "bookings"
-  | "calendar"
-  | "clients"
-  | "services"
-  | "locations"
-  | "profile"
-  | "statistics"
+  | 'dashboard'
+  | 'bookings'
+  | 'calendar'
+  | 'clients'
+  | 'services'
+  | 'locations'
+  | 'profile'
+  | 'statistics';
 
 export interface ProfessionalSlice {
-  activeTab: ProfessionalTab
-  selectedClinic: Clinic | null
-  showClinicSelection: boolean
-  services: ProfessionalService[]
-  bookings: ProfessionalBooking[]
-  clients: ProfessionalClient[]
-  locations: ProfessionalLocation[]
-  clinics: Clinic[]
-  stats: ProfessionalStats
-  setActiveTab: (tab: ProfessionalTab) => void
-  selectClinic: (clinic: Clinic) => void
-  loadData: () => void
+  activeTab: ProfessionalTab;
+  selectedClinic: Clinic | null;
+  showClinicSelection: boolean;
+  services: ProfessionalService[];
+  bookings: ProfessionalBooking[];
+  clients: ProfessionalClient[];
+  locations: ProfessionalLocation[];
+  clinics: Clinic[];
+  stats: ProfessionalStats;
+  setActiveTab: (tab: ProfessionalTab) => void;
+  selectClinic: (clinic: Clinic) => void;
+  loadData: () => void;
 }


### PR DESCRIPTION
- Replace "appointments/citas" with "bookings/reservas" across all UI components
- Update client components (dashboard, my-bookings, booking-history, navigation) to use generic service terminology
- Modify professional components (dashboard, statistics, calendar) for consistent booking nomenclature  
- Update company booking modal to use "reservas" terminology
- Add missing TypeScript types (Professional, Client, Booking, DashboardStats) in types/professional.ts
- Fix variable references (appointment.id → booking.id) in dashboard components
- Update example data to showcase diverse services (beauty, wellness, spa) instead of medical-only
- Modify SQL schema comments and migrations to use "booking" terminology
- Update professional-actions and hooks to use consistent booking stats (todayBookings, weeklyBookings)
- Enhance database structure to support any service industry with flexible fields (instructions, description, notes)
- Ensure all text references are industry-agnostic for beauty, fitness, education, medical, and other service sectors

This refactor makes the system truly generic and ready for any professional service booking scenario.